### PR TITLE
(#4) GetByPrettyUrlName for OverrideRecord objects.

### DIFF
--- a/integration-tests/docker-cts-listing-page-api/api/build/appsettings.inttest.json
+++ b/integration-tests/docker-cts-listing-page-api/api/build/appsettings.inttest.json
@@ -5,13 +5,6 @@
         "Password": "",
         "MaximumRetries": 5
     },
-    "PlaceholderAPI": {
-        "AliasName": "placehoolderv1"
-    },
-    "NSwag": {
-        "Title": "Placeholder API",
-        "Description": "Placeholder for a real API"
-    },
     "Logging": {
         "LogLevel": {
             "Default": "Warning"

--- a/integration-tests/features/override-name/getByName/name-match-exact-match.json
+++ b/integration-tests/features/override-name/getByName/name-match-exact-match.json
@@ -1,0 +1,12 @@
+{
+    "uniqueId": "C7707",
+    "type": "OverrideRecord",
+    "conceptId": [
+        "C7707"
+    ],
+    "name": {
+        "label": "Adult Soft Tissue Sarcoma",
+        "normalized": "adult soft tissue sarcoma"
+    },
+    "prettyUrlName": "adult-soft-tissue-sarcoma"
+}

--- a/integration-tests/features/override-name/getByName/name-match-not-a-match.json
+++ b/integration-tests/features/override-name/getByName/name-match-not-a-match.json
@@ -1,0 +1,3 @@
+{
+    "Message": "Could not find pretty URL name 'chicken'."
+}

--- a/integration-tests/features/override-name/getByName/name-match-partial-match.json
+++ b/integration-tests/features/override-name/getByName/name-match-partial-match.json
@@ -1,0 +1,3 @@
+{
+    "Message": "Could not find pretty URL name 'adult-soft'."
+}

--- a/integration-tests/features/override-name/getByName/name-match.feature
+++ b/integration-tests/features/override-name/getByName/name-match.feature
@@ -1,0 +1,20 @@
+Feature: Get override records by specifying the pretty URL name.
+
+    Background:
+        * url apiHost
+
+    Scenario Outline: Validate the query results when matching against a pretty-url name.
+
+        Given path 'override-name', prettyName
+        When method get
+        Then assert responseStatus == exStatus
+        And match response == read( expected )
+
+        Examples:
+            | exStatus | prettyName                | expected                      |
+            # Note: Multiple records with a single pretty-url name is a data error, and as the
+            # test data is a snapshot of production, it's not practical to create a deliberate
+            # test for a multiple record return.
+            | 200      | adult-soft-tissue-sarcoma | name-match-exact-match.json   |
+            | 404      | adult-soft                | name-match-partial-match.json |
+            | 404      | chicken                   | name-match-not-a-match.json   |

--- a/src/NCI.OCPL.Api.CTSListingPages/Controllers/OverrideController.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Controllers/OverrideController.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+using NCI.OCPL.Api.Common;
+using NCI.OCPL.Api.CTSListingPages;
+
+namespace NCI.OCPL.Api.CTSListingPages.Controllers
+{
+    /// <summary>
+    /// Controller for routes used when searching for or retrieving EVS override naming data.
+    /// </summary>
+    [Route("override-name")]
+    [ApiController]
+    public class OverrideController : ControllerBase
+    {
+        /// <summary>
+        /// The logger instance.
+        /// </summary>
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// The query service to use.
+        /// </summary>
+        private readonly IOverridesQueryService _overridesQueryService;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public OverrideController(ILogger<OverrideController> logger, IOverridesQueryService service)
+        {
+            _logger = logger;
+            _overridesQueryService = service;
+        }
+
+        /// <summary>
+        /// Retrieve a single OverrideRecord with a pretty-url name exactly matching the name parameter.
+        /// </summary>
+        /// <param name="prettyUrlName">The pretty-url name of the record to be retrieved.</param>
+        /// <returns>An OverrideRecord object or status 404 if an exact match is not found.</returns>
+        [HttpGet("{prettyUrlName}")]
+        public async Task<OverrideRecord> GetByPrettyUrlName(string prettyUrlName)
+        {
+            if (String.IsNullOrWhiteSpace(prettyUrlName))
+                throw new APIErrorException(400, "You must specify the prettyUrlName parameter.");
+
+
+            OverrideRecord result;
+            try
+            {
+                result = await _overridesQueryService.GetByPrettyUrlName(prettyUrlName);
+            }
+            catch (APIInternalException)
+            {
+                throw new APIErrorException(500, "Errors occured.");
+            }
+
+            if (result == null)
+                throw new APIErrorException(404, $"Could not find pretty URL name '{prettyUrlName}'.");
+
+            return result;
+        }
+    }
+}

--- a/src/NCI.OCPL.Api.CTSListingPages/Controllers/ValuesController.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Controllers/ValuesController.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable CS1591
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/NCI.OCPL.Api.CTSListingPages/Models/IListingInfo.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Models/IListingInfo.cs
@@ -1,0 +1,31 @@
+using Newtonsoft.Json;
+
+namespace NCI.OCPL.Api.CTSListingPages
+{
+    /// <summary>
+    /// Interface definining the fields common to all ListingPage entities.
+    /// </summary>
+    [JsonConverter(typeof(ListingInfoConverter))]
+    public interface IListingInfo
+    {
+        /// <summary>
+        /// Notes the subclass which represents a particular Elasticsearch ListingInfo document.
+        /// </summary>
+        RecordType Type { get; set; }
+
+        /// <summary>
+        /// An array of one or more concept IDs which mapping to this disease or intervention.
+        /// </summary>
+        string[] ConceptId { get; set; }
+
+        /// <summary>
+        /// Data structure containing the name of the disease or intervention.
+        /// </summary>
+        NameInfo Name { get; set; }
+
+        /// <summary>
+        /// Contains the document's browser-friendly path segment. NULL if none exists.
+        /// </summary>
+        string PrettyUrlName { get; set; }
+    }
+}

--- a/src/NCI.OCPL.Api.CTSListingPages/Models/ListingInfo.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Models/ListingInfo.cs
@@ -3,14 +3,25 @@ using Nest;
 namespace NCI.OCPL.Api.CTSListingPages
 {
     /// <summary>
-    /// Abstract base class common to EvsRecord and OverrideRecord.
+    /// Base class common to EvsRecord and OverrideRecord.
+    ///
+    /// This class implements the properties defined in IListingInfo, however it
+    /// expressly does *NOT* "implement" IListingInfo. The intent is to enforce the
+    /// use of classes implementing IListingInfo for serializiation, while providing
+    /// a single class for maintaining the NEST attribute mapping data.
     /// </summary>
-    abstract public class ListingInfo
+    abstract public class ListingInfo : IListingInfo
     {
+        /// <summary>
+        /// Notes the subclass which represents a particular Elasticsearch ListingInfo document.
+        /// </summary>
+        [Keyword(Name = "type")]
+        public RecordType Type {get; set;}
+
         /// <summary>
         /// An array of one or more concept IDs which mapping to this disease or intervention.
         /// </summary>
-        [Keyword(Name = "label")]
+        [Keyword(Name = "concept_id")]
         public string[] ConceptId {get;set;}
 
         /// <summary>

--- a/src/NCI.OCPL.Api.CTSListingPages/Models/ListingInfoConverter.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Models/ListingInfoConverter.cs
@@ -1,0 +1,57 @@
+using System;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
+
+namespace NCI.OCPL.Api.CTSListingPages
+{
+    /// <summary>
+    /// Determines how to deserialize a generic IListingInfo into a specific implemenation.
+    /// </summary>
+    public class ListingInfoConverter : JsonConverter<IListingInfo>
+    {
+        /// <summary>
+        /// Deserializes an instance of IDrugResource into either a DrugAlias or a DrugTerm.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="objectType"></param>
+        /// <param name="existingValue"></param>
+        /// <param name="hasExistingValue"></param>
+        /// <param name="serializer"></param>
+        /// <returns></returns>
+        public override IListingInfo ReadJson(JsonReader reader, Type objectType, IListingInfo existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var jsonObject = JObject.Load(reader);
+            var drugItem = default(IListingInfo);
+            string type = jsonObject["type"].Value<string>();
+
+            switch (type != null ? type.ToLower() : type)
+            {
+                case "evsrecord":
+                    drugItem = new EvsRecord();
+                    break;
+
+                case "overriderecord":
+                    drugItem = new OverrideRecord();
+                    break;
+            }
+            serializer.Populate(jsonObject.CreateReader(), drugItem);
+            return drugItem;
+        }
+
+        /// <summary>
+        /// Report that this covnerter can't be used for serializing.
+        /// Force the object's default (more specific) serialzation to be used instead.
+        /// </summary>
+        /// <value>Always returns false.</value>
+        public override bool CanWrite { get { return false; } }
+
+        /// <summary>
+        /// This method exists for the sake of satisfying the abstract base class but is not used.
+        /// </summary>
+        public override void WriteJson(JsonWriter writer, IListingInfo value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+}

--- a/src/NCI.OCPL.Api.CTSListingPages/Models/Options/ListingPageAPIOptions.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Models/Options/ListingPageAPIOptions.cs
@@ -9,6 +9,6 @@ namespace NCI.OCPL.Api.CTSListingPages.Models
         /// Gets or sets the alias name for the Elasticsearch Collection we will use.
         /// </summary>
         /// <value>The name of the alias.</value>
-        public string AliasName { get; set; }
+        public string ListingInfoAliasName { get; set; }
     }
 }

--- a/src/NCI.OCPL.Api.CTSListingPages/Models/RecordType.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Models/RecordType.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace NCI.OCPL.Api.CTSListingPages
+{
+    /// <summary>
+    /// Friendly names for denoting the type of a ListingInfo Elasticsearch document.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum RecordType
+    {
+        /// <summary>
+        /// The document is an EvsRecord.
+        /// </summary>
+        EvsRecord,
+
+        /// <summary>
+        /// The document is an OverrideRecord.
+        /// </summary>
+        OverrideRecord
+    }
+}

--- a/src/NCI.OCPL.Api.CTSListingPages/NCI.OCPL.Api.CTSListingPages.csproj
+++ b/src/NCI.OCPL.Api.CTSListingPages/NCI.OCPL.Api.CTSListingPages.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
@@ -14,6 +18,8 @@
         <Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.2.2" />
+    <PackageReference Include="NEST" Version="5.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NCI.OCPL.Api.CTSListingPages/Program.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Program.cs
@@ -10,13 +10,22 @@ using Microsoft.Extensions.Logging;
 
 namespace NCI.OCPL.Api.CTSListingPages
 {
+    /// <summary>
+    /// Main program for running the CTS listing page API.
+    /// </summary>
     public class Program
     {
+        /// <summary>
+        /// The main entry point for running the CTS listing page API.
+        /// </summary>
         public static void Main(string[] args)
         {
             CreateWebHostBuilder(args).Build().Run();
         }
 
+        /// <summary>
+        /// CreateWebHostBuilder
+        /// </summary>
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>();

--- a/src/NCI.OCPL.Api.CTSListingPages/Services/ESOverrideQueryService.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Services/ESOverrideQueryService.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Linq;
+
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
+using Nest;
+
+using System.Threading.Tasks;
+using NCI.OCPL.Api.Common;
+using NCI.OCPL.Api.CTSListingPages.Models;
+
+namespace NCI.OCPL.Api.CTSListingPages.Services
+{
+    /// <summary>
+    /// Elasticsearch implemenation of the service for retrieving EVS override information.
+    /// </summary>
+    public class ESOverrideQueryService : IOverridesQueryService
+    {
+        /// <summary>
+        /// The elasticsearch client
+        /// </summary>
+        private IElasticClient _elasticClient;
+
+        /// <summary>
+        /// The API options.
+        /// </summary>
+        protected readonly ListingPageAPIOptions _apiOptions;
+
+        /// <summary>
+        /// A logger to use for logging
+        /// </summary>
+        private readonly ILogger<ESOverrideQueryService> _logger;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public ESOverrideQueryService(IElasticClient client, IOptions<ListingPageAPIOptions> apiOptionsAccessor,
+            ILogger<ESOverrideQueryService> logger)
+        {
+            _elasticClient = client;
+            _apiOptions = apiOptionsAccessor.Value;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Retrieve a single OverrideRecord with a pretty-url name exactly matching the name parameter.
+        /// </summary>
+        /// <param name="prettyUrlName">The pretty-url name of the record to be retrieved.</param>
+        /// <returns>An OverrideRecord object or null if an exact match is not found.</returns>
+        public async Task<OverrideRecord> GetByPrettyUrlName(string prettyUrlName)
+        {
+            // Set up the SearchRequest to send to elasticsearch.
+            Indices index = Indices.Index(new string[] { this._apiOptions.ListingInfoAliasName });
+            Types types = Types.Type(new string[]{ "ListingInfo" });
+            SearchRequest request = new SearchRequest(index, types)
+            {
+                Query = new TermQuery { Field = "pretty_url_name", Value = prettyUrlName.ToString() } &&
+                        new TermQuery { Field = "type", Value = "OverrideRecord" }
+            };
+
+            ISearchResponse<OverrideRecord> response = null;
+            try
+            {
+                response = await _elasticClient.SearchAsync<OverrideRecord>(request);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Error searching index: '{this._apiOptions.ListingInfoAliasName}'.");
+                throw new APIInternalException("errors occured");
+            }
+
+            if (!response.IsValid)
+            {
+                String msg = $"Invalid response when searching for pretty URL name '{prettyUrlName}'.";
+                _logger.LogError(msg);
+                _logger.LogError(response.DebugInformation);
+                throw new APIInternalException("errors occured");
+            }
+
+            OverrideRecord record = null;
+
+            // If there is are any records in the response, the lookup was successful.
+            if(response.Total > 0)
+            {
+                record = response.Documents.First();
+
+                if( response.Total > 1)
+                {
+                    _logger.LogWarning($"Found multiple records for pretty URL name '{prettyUrlName}'.");
+                }
+            }
+
+            return record;
+        }
+    }
+}

--- a/src/NCI.OCPL.Api.CTSListingPages/Startup.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Startup.cs
@@ -12,9 +12,13 @@ using Microsoft.Extensions.Options;
 
 using NCI.OCPL.Api.Common;
 using NCI.OCPL.Api.CTSListingPages.Models;
+using NCI.OCPL.Api.CTSListingPages.Services;
 
 namespace NCI.OCPL.Api.CTSListingPages
 {
+    /// <summary>
+    /// Defines the configuration of the Listing Page API.
+    /// </summary>
     public class Startup : NciStartupBase
     {
         /// <summary>
@@ -43,7 +47,8 @@ namespace NCI.OCPL.Api.CTSListingPages
         /// <param name="services">Services.</param>
         protected override void AddAppServices(IServiceCollection services)
         {
-            // Add our Query Services
+            // Add our Query Services.
+            services.AddTransient<IOverridesQueryService, ESOverrideQueryService>();
 
             services.Configure<ListingPageAPIOptions>(Configuration.GetSection("ListingPageAPI"));
         }

--- a/src/NCI.OCPL.Api.CTSListingPages/appsettings.json
+++ b/src/NCI.OCPL.Api.CTSListingPages/appsettings.json
@@ -6,7 +6,7 @@
         "MaximumRetries": 5
     },
     "ListingPageAPI": {
-        "AliasName": "listingpage1"
+        "ListingInfoAliasName": "listinginfov1"
     },
     "NSwag": {
         "Title": "CTS Listing Page API",

--- a/src/NCI.OCPL.Api.CTSListingPages/interfaces/IOverridesQueryService.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/interfaces/IOverridesQueryService.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace NCI.OCPL.Api.CTSListingPages
+{
+    /// <summary>
+    /// Interface definition for retrieving EVS override information.
+    /// </summary>
+    public interface IOverridesQueryService
+    {
+        /// <summary>
+        /// Retrieve a single OverrideRecord with a pretty-url name exactly matching the name parameter.
+        /// </summary>
+        /// <param name="prettyUrlName">The pretty-url name of the record to be retrieved.</param>
+        /// <returns>An OverrideRecord object or null if an exact match is not found.</returns>
+        Task<OverrideRecord> GetByPrettyUrlName(string prettyUrlName);
+    }
+}

--- a/src/NCI.OCPL.Api.Common.Testing/TestingTools.cs
+++ b/src/NCI.OCPL.Api.Common.Testing/TestingTools.cs
@@ -1,13 +1,13 @@
 ﻿using System.IO;
 using System.Reflection;
-
+using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
 
 namespace NCI.OCPL.Api.Common.Testing
 {
     /// <summary>
-    /// Helper tools for loading responses from files and 
+    /// Helper tools for loading responses from files and
     /// deserializing XML to objects.
     /// </summary>
     public static class TestingTools
@@ -42,6 +42,18 @@ namespace NCI.OCPL.Api.Common.Testing
             Stream contents = File.OpenRead(path);
 
             return contents;
+        }
+
+        /// <summary>
+        /// Gets a string as a stream. Useful for when you don't want to maintain a
+        /// separate file but have a string which needs to look like it came from one.
+        /// </summary>
+        /// <param name="dataString">The string to convert.</param>
+        /// <returns></returns>
+        public static Stream GetStringAsStream(string dataString)
+        {
+            byte[] byteArray = Encoding.UTF8.GetBytes(dataString);
+            return new MemoryStream(byteArray);
         }
 
         /// <summary>

--- a/src/NCI.OCPL.Api.Common/APIInternalException.cs
+++ b/src/NCI.OCPL.Api.Common/APIInternalException.cs
@@ -1,0 +1,18 @@
+
+namespace NCI.OCPL.Api.Common
+{
+    /// <summary>
+    /// Represents an internal error encountered by the API.
+    /// This exception is intended to be thrown by API services and caught by controllers.
+    /// It is **NOT** intended to be returned to the API's consumer.
+    /// </summary>
+    public class APIInternalException : System.Exception
+    {
+        /// <summary>
+        /// Creates a new instance of the APIErrorException
+        /// </summary>
+        /// <param name="message"></param>
+        public APIInternalException(string message) :
+        base(message) {}
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Controllers/OverrideControllerTest.GetByPrettyUrlName.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Controllers/OverrideControllerTest.GetByPrettyUrlName.cs
@@ -1,0 +1,119 @@
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging.Testing;
+using Moq;
+using Xunit;
+
+using NCI.OCPL.Api.Common;
+using NCI.OCPL.Api.CTSListingPages.Controllers;
+
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    public partial class OverrideControllerTest
+    {
+        /// <summary>
+        /// Verify correcting handling of invalid names.
+        /// </summary>
+        [Theory]
+        [InlineData(new object[] { null })]
+        [InlineData(new object[] { "" })]       // Can't use String.Empty because it's a property instead of a constant.
+        [InlineData(new object[] { "    " })]
+        public async void GetByPrettyUrlName_InvalidName(string prettyUrlName)
+        {
+            Mock<IOverridesQueryService> querySvc = new Mock<IOverridesQueryService>();
+            querySvc.Setup(
+                svc => svc.GetByPrettyUrlName(
+                    It.IsAny<string>()
+                )
+            )
+            .Returns(Task.FromResult(new OverrideRecord()));
+
+            OverrideController controller = new OverrideController(NullLogger<OverrideController>.Instance, querySvc.Object);
+
+            var exception = await Assert.ThrowsAsync<APIErrorException>(
+                () => controller.GetByPrettyUrlName(prettyUrlName)
+            );
+
+            querySvc.Verify(
+                svc => svc.GetByPrettyUrlName(It.IsAny<string>()),
+                Times.Never
+            );
+
+            Assert.Equal("You must specify the prettyUrlName parameter.", exception.Message);
+            Assert.Equal(400, exception.HttpStatusCode);
+        }
+
+        /// <summary>
+        /// Verify correct handling of a valid name.
+        /// </summary>
+        [Fact]
+        public async void GetByPrettyUrlName_ValidName()
+        {
+            const string theName = "recurrent-adult-brain";
+
+            OverrideRecord testRecord = new OverrideRecord
+            {
+                UniqueId = "C7884",
+                ConceptId = new string[] { "C7884" },
+                Name = new NameInfo
+                {
+                    Label = "Recurrent Adult Brain Tumors",
+                    Normalized = "recurrent adult brain tumors"
+                },
+                PrettyUrlName = "recurrent-adult-brain"
+            };
+
+            Mock<IOverridesQueryService> querySvc = new Mock<IOverridesQueryService>();
+            querySvc.Setup(
+                svc => svc.GetByPrettyUrlName(
+                    It.IsAny<string>()
+                )
+            )
+            .Returns(Task.FromResult(testRecord));
+
+            // Call the controller.
+            OverrideController controller = new OverrideController(NullLogger<OverrideController>.Instance, querySvc.Object);
+            OverrideRecord actual = await controller.GetByPrettyUrlName(theName);
+
+            Assert.Equal(testRecord, actual);
+
+            // Verify the query layer is called:
+            //  a) with the passed value.
+            //  b) exactly once.
+            querySvc.Verify(
+                svc => svc.GetByPrettyUrlName(theName),
+                Times.Once,
+                $"IOverridesQueryService:GetByPrettyUrlName() should be called once, with prettyUrlName = '{theName}"
+            );
+
+        }
+
+        /// <summary>
+        /// Verify correct handling of an internal error in the service layer.
+        /// </summary>
+        [Fact]
+        public async void GetByPrettyUrlName_ServiceFailure()
+        {
+            const string theName = "recurrent-adult-brain";
+
+            Mock<IOverridesQueryService> querySvc = new Mock<IOverridesQueryService>();
+            querySvc.Setup(
+                svc => svc.GetByPrettyUrlName(
+                    It.IsAny<string>()
+                )
+            )
+            .Throws(new APIInternalException("Kaboom!"));
+
+            // Call the controller, we're not expecting a result, so don't save it.
+            OverrideController controller = new OverrideController(NullLogger<OverrideController>.Instance, querySvc.Object);
+
+            var exception = await Assert.ThrowsAsync<APIErrorException>(
+                () => controller.GetByPrettyUrlName(theName)
+            );
+
+            Assert.Equal("Errors occured.", exception.Message);
+            Assert.Equal(500, exception.HttpStatusCode);
+        }
+
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Models/NameInfoComparer.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Models/NameInfoComparer.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    public class NameInfoComparer : IEqualityComparer<NameInfo>
+    {
+        public bool Equals(NameInfo x, NameInfo y)
+        {
+            // If the items are both null, or if one or the other is null, return
+            // the correct response right away.
+            if (x == null && y == null)
+            {
+                return true;
+            }
+            else if (x == null || y == null)
+            {
+                return false;
+            }
+
+            bool isEqual =
+                x.Label.Equals(y.Label)
+                && x.Normalized.Equals(y.Normalized);
+
+            return isEqual;
+        }
+
+        public int GetHashCode(NameInfo obj)
+        {
+            int hash = 0;
+
+            hash ^=
+                obj.Label.GetHashCode()
+                ^obj.Normalized.GetHashCode();
+
+            return hash;
+        }
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Models/OverrideRecordComparer.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Models/OverrideRecordComparer.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using System.Collections.Generic;
+
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    /// <summary>
+    /// An IEqualityComparer for OverrideRecord objects.
+    /// </summary>
+    public class OverrideRecordComparer : IEqualityComparer<OverrideRecord>
+    {
+        public bool Equals(OverrideRecord x, OverrideRecord y)
+        {
+            // If the items are both null, or if one or the other is null, return
+            // the correct response right away.
+            if (x == null && y == null)
+            {
+                return true;
+            }
+            else if (x == null || y == null)
+            {
+                return false;
+            }
+
+            bool isEqual =
+                x.Type.Equals(y.Type)
+                && x.ConceptId.SequenceEqual(y.ConceptId)
+                && x.PrettyUrlName.Equals(y.PrettyUrlName)
+                && x.UniqueId.Equals(y.UniqueId)
+                && new NameInfoComparer().Equals(x.Name, y.Name);
+
+            return isEqual;
+        }
+
+        public int GetHashCode(OverrideRecord obj)
+        {
+            int hash = 0;
+
+            hash ^=
+                obj.Type.GetHashCode()
+                ^obj.ConceptId.GetHashCode()
+                ^obj.PrettyUrlName.GetHashCode()
+                ^obj.UniqueId.GetHashCode()
+                ^(new NameInfoComparer()).GetHashCode(obj.Name);
+
+            return hash;
+        }
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Services/ESOverrideQueryServiceTest.GetByPrettyUrlName.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Services/ESOverrideQueryServiceTest.GetByPrettyUrlName.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+using Elasticsearch.Net;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging.Testing;
+using Moq;
+using Nest;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+using NCI.OCPL.Api.Common.Testing;
+using NCI.OCPL.Api.CTSListingPages.Models;
+using NCI.OCPL.Api.CTSListingPages.Services;
+
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    public partial class ESOverrideQueryServiceTest
+    {
+        /// <summary>
+        /// Test to verify that Elasticsearch requests are being assembled correctly.
+        /// </summary>
+        [Fact]
+        public async void GetByPrettyUrlName_TestRequestSetup()
+        {
+            const string theName = "recurrent-adult-brain";
+            JObject expectedRequest = JObject.Parse(
+@"{
+    ""query"": {
+        ""bool"": {
+            ""must"": [
+                { ""term"": { ""pretty_url_name"": { ""value"": ""recurrent-adult-brain"" } } },
+                { ""term"": { ""type"":            { ""value"": ""OverrideRecord"" } } }
+            ]
+        }
+    }
+}
+");
+
+            Uri esURI = null;
+            string esContentType = String.Empty;
+            HttpMethod esMethod = HttpMethod.DELETE; // Basically, something other than the expected value.
+
+            JObject requestBody = null;
+
+            ElasticsearchInterceptingConnection conn = new ElasticsearchInterceptingConnection();
+            conn.RegisterRequestHandlerForType<Nest.SearchResponse<OverrideRecord>>((req, res) =>
+            {
+                // We don't really care about the response for this test.
+                res.Stream = MockEmptyResponse;
+                res.StatusCode = 200;
+
+                esURI = req.Uri;
+                esContentType = req.ContentType;
+                esMethod = req.Method;
+                requestBody = conn.GetRequestPost(req);
+            });
+
+            // The URI does not matter, an InMemoryConnection never requests from the server.
+            var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+
+            var connectionSettings = new ConnectionSettings(pool, conn);
+            IElasticClient client = new ElasticClient(connectionSettings);
+
+            // Setup the mocked Options
+            IOptions<ListingPageAPIOptions> clientOptions = GetMockOptions();
+
+            ESOverrideQueryService query = new ESOverrideQueryService(client, clientOptions, new NullLogger<ESOverrideQueryService>());
+
+            // For this test, we don't really care that this returns anything, only that the intercepting connection
+            // sets up the request correctly.
+            await query.GetByPrettyUrlName(theName);
+
+            Assert.Equal("/listingpagev1/ListingInfo/_search", esURI.AbsolutePath);
+            Assert.Equal("application/json", esContentType);
+            Assert.Equal(HttpMethod.POST, esMethod);
+            Assert.Equal(expectedRequest, requestBody, new JTokenEqualityComparer());
+        }
+
+        public static IEnumerable<object[]> GetByPrettyUrlName_Scenarios = new[]
+        {
+            new object[] { new GetByPrettyUrlName_NoResults() },
+            new object[] { new GetByPrettyUrlName_SingleResult() },
+            new object[] { new GetByPrettyUrlName_MultipleResults() }
+        };
+
+        /// <summary>
+        /// Test to verify handling when no results are returned.
+        /// </summary>
+        [Theory, MemberData(nameof(GetByPrettyUrlName_Scenarios))]
+        public async void GetByPrettyUrlName_TestNoResultsFound(GetByPrettyUrlName_BaseScenario data)
+        {
+            ElasticsearchInterceptingConnection conn = new ElasticsearchInterceptingConnection();
+            conn.RegisterRequestHandlerForType<Nest.SearchResponse<OverrideRecord>>((req, res) =>
+            {
+                res.Stream = TestingTools.GetStringAsStream(data.MockESResponse);
+                res.StatusCode = 200;
+            });
+
+            // The URI does not matter, an InMemoryConnection never requests from the server.
+            var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+
+            var connectionSettings = new ConnectionSettings(pool, conn);
+            IElasticClient client = new ElasticClient(connectionSettings);
+
+            // Setup the mocked Options
+            IOptions<ListingPageAPIOptions> clientOptions = GetMockOptions();
+
+            ESOverrideQueryService query = new ESOverrideQueryService(client, clientOptions, new NullLogger<ESOverrideQueryService>());
+
+            // The actual input doesn't matter for this test since the result is pre-determined.
+            OverrideRecord result = await query.GetByPrettyUrlName("chicken");
+            Assert.Equal(data.ExpectedData, result, new OverrideRecordComparer());
+        }
+
+
+        /// <summary>
+        /// Simulates a "no results found" response from Elasticsearch so we
+        /// have something for tests where we don't care about the response.
+        /// </summary>
+        private Stream MockEmptyResponse
+        {
+            get
+            {
+                string empty = @"
+{
+    ""took"": 223,
+    ""timed_out"": false,
+    ""_shards"": {
+                ""total"": 1,
+        ""successful"": 1,
+        ""skipped"": 0,
+        ""failed"": 0
+    },
+    ""hits"": {
+                ""total"": 0,
+        ""max_score"": null,
+        ""hits"": []
+    }
+}";
+                byte[] byteArray = Encoding.UTF8.GetBytes(empty);
+                return new MemoryStream(byteArray);
+            }
+        }
+
+        /// <summary>
+        /// Mock Elasticsearch configuraiton options.
+        /// </summary>
+        private IOptions<ListingPageAPIOptions> GetMockOptions()
+        {
+            Mock<IOptions<ListingPageAPIOptions>> clientOptions = new Mock<IOptions<ListingPageAPIOptions>>();
+            clientOptions
+                .SetupGet(opt => opt.Value)
+                .Returns(new ListingPageAPIOptions()
+                {
+                    ListingInfoAliasName = "listingpagev1"
+                }
+            );
+
+            return clientOptions.Object;
+        }
+
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESOverrideQueryService/GetByPrettyUrlName_BaseScenario.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESOverrideQueryService/GetByPrettyUrlName_BaseScenario.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    public abstract class GetByPrettyUrlName_BaseScenario
+    {
+        /// <summary>
+        /// The mock response from Elasticsearch.
+        /// </summary>
+        /// <value></value>
+        public abstract string MockESResponse {get;}
+
+        /// <summary>
+        /// The Override record which the service is expected to return from the response.
+        /// </summary>
+        public abstract OverrideRecord ExpectedData { get; }
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESOverrideQueryService/GetByPrettyUrlName_MultipleResults.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESOverrideQueryService/GetByPrettyUrlName_MultipleResults.cs
@@ -1,0 +1,81 @@
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    /// <summary>
+    /// Test for data issues where a pretty URL returns multiple documents.
+    /// </summary>
+    class GetByPrettyUrlName_MultipleResults : GetByPrettyUrlName_BaseScenario
+    {
+        public override string MockESResponse => @"
+{
+    ""took"": 20,
+    ""timed_out"": false,
+    ""_shards"": {
+        ""total"": 1,
+        ""successful"": 1,
+        ""skipped"": 0,
+        ""failed"": 0
+    },
+    ""hits"": {
+        ""total"": 2,
+        ""max_score"": 2.2335923,
+        ""hits"": [
+            {
+                ""_index"": ""listinginfov1"",
+                ""_type"": ""ListingInfo"",
+                ""_id"": ""AXUtWHSZPZ7BGoClhnsQ"",
+                ""_score"": 2.2335923,
+                ""_source"": {
+                    ""type"": ""OverrideRecord"",
+                    ""concept_id"": [
+                        ""C123"",
+                        ""C456"",
+                        ""C789"",
+                        ""C876""
+                    ],
+                    ""unique_id"": ""C123,C456,C789,C876"",
+                    ""name"": {
+                        ""label"": ""First item with this pretty url"",
+                        ""normalized"": ""first item with  this pretty url""
+                    },
+                    ""pretty_url_name"": ""duplicated-pretty-url""
+                }
+            },
+            {
+                ""_index"": ""listinginfov1"",
+                ""_type"": ""ListingInfo"",
+                ""_id"": ""AXUtWHSZPZ7BGoClhnsQ"",
+                ""_score"": 2.2335923,
+                ""_source"": {
+                    ""type"": ""OverrideRecord"",
+                    ""concept_id"": [
+                        ""C123"",
+                        ""C456"",
+                        ""C789"",
+                        ""C876""
+                    ],
+                    ""unique_id"": ""C123,C456,C789,C876"",
+                    ""name"": {
+                        ""label"": ""Second item with this pretty url"",
+                        ""normalized"": ""second item with  this pretty url""
+                    },
+                    ""pretty_url_name"": ""duplicated-pretty-url""
+                }
+            }
+        ]
+    }
+}";
+
+        public override OverrideRecord ExpectedData => new OverrideRecord
+        {
+            Type = RecordType.OverrideRecord,
+            ConceptId = new string[] {"C123", "C456", "C789", "C876" },
+            Name = new NameInfo
+            {
+                Label = "First item with this pretty url",
+                Normalized = "first item with  this pretty url"
+            },
+            PrettyUrlName = "duplicated-pretty-url",
+            UniqueId = "C123,C456,C789,C876"
+        };
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESOverrideQueryService/GetByPrettyUrlName_NoResults.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESOverrideQueryService/GetByPrettyUrlName_NoResults.cs
@@ -1,0 +1,24 @@
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    class GetByPrettyUrlName_NoResults : GetByPrettyUrlName_BaseScenario
+    {
+        public override string MockESResponse => @"
+{
+    ""took"": 223,
+    ""timed_out"": false,
+    ""_shards"": {
+                ""total"": 1,
+        ""successful"": 1,
+        ""skipped"": 0,
+        ""failed"": 0
+    },
+    ""hits"": {
+                ""total"": 0,
+        ""max_score"": null,
+        ""hits"": []
+    }
+}";
+
+        public override OverrideRecord ExpectedData => null;
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESOverrideQueryService/GetByPrettyUrlName_SingleResult.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESOverrideQueryService/GetByPrettyUrlName_SingleResult.cs
@@ -1,0 +1,57 @@
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    class GetByPrettyUrlName_SingleResult : GetByPrettyUrlName_BaseScenario
+    {
+        public override string MockESResponse => @"
+{
+    ""took"": 20,
+    ""timed_out"": false,
+    ""_shards"": {
+        ""total"": 1,
+        ""successful"": 1,
+        ""skipped"": 0,
+        ""failed"": 0
+    },
+    ""hits"": {
+        ""total"": 1,
+        ""max_score"": 2.2335923,
+        ""hits"": [
+            {
+                ""_index"": ""listinginfov1"",
+                ""_type"": ""ListingInfo"",
+                ""_id"": ""AXUtWHSZPZ7BGoClhnsQ"",
+                ""_score"": 2.2335923,
+                ""_source"": {
+                    ""type"": ""OverrideRecord"",
+                    ""concept_id"": [
+                        ""C114967"",
+                        ""C114964"",
+                        ""C114972"",
+                        ""C114963""
+                    ],
+                    ""unique_id"": ""C114967,C114964,C114972,C114963"",
+                    ""name"": {
+                        ""label"": ""Childhood Brain Cancer"",
+                        ""normalized"": ""childhood brain cancer""
+                    },
+                    ""pretty_url_name"": ""childhood-brain-cancer""
+                }
+            }
+        ]
+    }
+}";
+
+        public override OverrideRecord ExpectedData => new OverrideRecord
+        {
+            Type = RecordType.OverrideRecord,
+            ConceptId = new string[] {"C114967", "C114964", "C114972", "C114963" },
+            Name = new NameInfo
+            {
+                Label = "Childhood Brain Cancer",
+                Normalized = "childhood brain cancer"
+            },
+            PrettyUrlName = "childhood-brain-cancer",
+            UniqueId = "C114967,C114964,C114972,C114963"
+        };
+    }
+}


### PR DESCRIPTION
- Rework ListingInfo and related models to support EvsRecord and OverrideRecord
  being stored in the same index.
- Change ListingPageAPIOptions.AliasName to ListingInfoAliasName to support
  separate indices for ListingInfo vs. LabelInformation.
- Add APIInternalException to Common in order to move toward only using
  APIErrorException in controllers. This needs to be copied to the template.
- New GetStringAsStream method on TestingTools class. This also needs to
  be copied to the template project.
- Removed unneeded config overrides from appsettings.inttest.json.

Close #4 