### PR TITLE
(#10) Implement LabelLookup Controller Get method

### DIFF
--- a/cts-dynamic-listing-api.sln
+++ b/cts-dynamic-listing-api.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
@@ -13,7 +13,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NCI.OCPL.Api.CTSListingPage
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{7FBDE146-4DD7-4B1B-9F35-A76F6F816130}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NCI.OCPL.Api.CTSListingPages", "test\NCI.OCPL.Api.CTSListingPages.Tests\NCI.OCPL.Api.CTSListingPages.Tests.csproj", "{F6999F98-ABDF-4F3C-8094-94E1059F7EE6}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NCI.OCPL.Api.CTSListingPages.Tests", "test\NCI.OCPL.Api.CTSListingPages.Tests\NCI.OCPL.Api.CTSListingPages.Tests.csproj", "{F6999F98-ABDF-4F3C-8094-94E1059F7EE6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/integration-tests/docker-cts-listing-page-api/api/build/appsettings.inttest.json
+++ b/integration-tests/docker-cts-listing-page-api/api/build/appsettings.inttest.json
@@ -5,13 +5,6 @@
         "Password": "",
         "MaximumRetries": 5
     },
-    "PlaceholderAPI": {
-        "AliasName": "placehoolderv1"
-    },
-    "NSwag": {
-        "Title": "Placeholder API",
-        "Description": "Placeholder for a real API"
-    },
     "Logging": {
         "LogLevel": {
             "Default": "Warning"

--- a/integration-tests/features/label-information/get/name-match-both-match.json
+++ b/integration-tests/features/label-information/get/name-match-both-match.json
@@ -1,0 +1,5 @@
+{
+	"prettyUrlName": "prevention",
+	"idString": "prevention",
+	"label": "Prevention"
+}

--- a/integration-tests/features/label-information/get/name-match-id-string-match.json
+++ b/integration-tests/features/label-information/get/name-match-id-string-match.json
@@ -1,0 +1,5 @@
+{
+	"prettyUrlName": "health-services-research",
+	"idString": "health_services_research",
+	"label": "Health Services Research"
+}

--- a/integration-tests/features/label-information/get/name-match-pretty-url-name-match.json
+++ b/integration-tests/features/label-information/get/name-match-pretty-url-name-match.json
@@ -1,0 +1,5 @@
+{
+	"prettyUrlName": "health-services-research",
+	"idString": "health_services_research",
+	"label": "Health Services Research"
+}

--- a/integration-tests/features/label-information/get/name-match.feature
+++ b/integration-tests/features/label-information/get/name-match.feature
@@ -1,0 +1,17 @@
+Feature: Get label information by specifying the name.
+
+    Background:
+        * url apiHost
+
+    Scenario Outline: Validate the query results when matching against name.
+
+        Given path 'label-lookup', name
+        When method get
+        Then assert responseStatus == exStatus
+        And match response == read( expected )
+
+        Examples:
+            | exStatus | name                      | expected                                |
+            | 200      | health-services-research  | name-match-pretty-url-name-match.json   |
+            | 200      | health_services_research  | name-match-id-string-match.json         |
+            | 200      | prevention                | name-match-both-match.json              |

--- a/integration-tests/features/label-information/get/not-found-chicken.json
+++ b/integration-tests/features/label-information/get/not-found-chicken.json
@@ -1,0 +1,3 @@
+{
+    "Message": "Could not find label or identifier 'chicken'."
+}

--- a/integration-tests/features/label-information/get/not-found-screening-diagnostic.json
+++ b/integration-tests/features/label-information/get/not-found-screening-diagnostic.json
@@ -1,0 +1,3 @@
+{
+    "Message": "Could not find label or identifier 'screening-diagnostic'."
+}

--- a/integration-tests/features/label-information/get/not-found.feature
+++ b/integration-tests/features/label-information/get/not-found.feature
@@ -1,0 +1,16 @@
+Feature: Fail to retrieve label information by specifying a nonexistent name.
+
+    Background:
+        * url apiHost
+
+    Scenario Outline: Validate no result found when matching against name.
+
+        Given path 'label-lookup', name
+        When method get
+        Then assert responseStatus == exStatus
+        And match response == read( expected )
+
+        Examples:
+            | exStatus | name                      | expected                               |
+            | 404      | chicken                   | not-found-chicken.json                 |
+            | 404      | screening-diagnostic      | not-found-screening-diagnostic.json    |

--- a/src/NCI.OCPL.Api.CTSListingPages/Controllers/LabelLookupController.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Controllers/LabelLookupController.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+using NCI.OCPL.Api.Common;
+using NCI.OCPL.Api.CTSListingPages;
+
+namespace NCI.OCPL.Api.CTSListingPages.Controllers
+{
+    /// <summary>
+    /// Controller for routes used when searching for or retrieving label information data.
+    /// </summary>
+    [Route("label-lookup")]
+    public class LabelLookupController : ControllerBase
+    {
+        /// <summary>
+        /// The logger instance.
+        /// </summary>
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// The query service to use.
+        /// </summary>
+        private readonly ILabelLookupQueryService _labelLookupQueryService;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public LabelLookupController(ILogger<LabelLookupController> logger, ILabelLookupQueryService service)
+        {
+            _logger = logger;
+            _labelLookupQueryService = service;
+        }
+
+        /// <summary>
+        /// Retrieve a single LabelInformation with a pretty-url name or identifier exactly matching the name parameter.
+        /// </summary>
+        /// <param name="name">The name - either the pretty-url name or identifier string - of the record to be retrieved.</param>
+        /// <returns>A LabelInformation object or status 404 if an exact match is not found.</returns>
+        [HttpGet("{name}")]
+        public async Task<LabelInformation> Get(string name)
+        {
+            if (String.IsNullOrWhiteSpace(name))
+                throw new APIErrorException(400, "You must specify the name parameter.");
+
+
+            LabelInformation result;
+            try
+            {
+                result = await _labelLookupQueryService.Get(name);
+            }
+            catch (APIInternalException)
+            {
+                throw new APIErrorException(500, "Errors occured.");
+            }
+
+            if (result == null)
+                throw new APIErrorException(404, $"Could not find label or identifier '{name}'.");
+
+            return result;
+        }
+    }
+}

--- a/src/NCI.OCPL.Api.CTSListingPages/Controllers/ValuesController.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Controllers/ValuesController.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#pragma warning disable CS1591
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/NCI.OCPL.Api.CTSListingPages/Interfaces/ILabelLookupQueryService.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Interfaces/ILabelLookupQueryService.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace NCI.OCPL.Api.CTSListingPages
+{
+    /// <summary>
+    /// Interface definition for retrieving label information.
+    /// </summary>
+    public interface ILabelLookupQueryService
+    {
+        /// <summary>
+        /// Retrieve a single LabelInformation with a pretty-url name or identifier exactly matching the name parameter.
+        /// </summary>
+        /// <param name="name">The name - either the pretty-url name or identifier string - of the record to be retrieved.</param>
+        /// <returns>A LabelInformation object or null if an exact match is not found.</returns>
+        Task<LabelInformation> Get(string name);
+    }
+}

--- a/src/NCI.OCPL.Api.CTSListingPages/Models/Options/ListingPageAPIOptions.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Models/Options/ListingPageAPIOptions.cs
@@ -1,14 +1,14 @@
 namespace NCI.OCPL.Api.CTSListingPages.Models
 {
     /// <summary>
-    /// Configuration options for the Drug Dictionary Term API.
+    /// Configuration options for the Dynamic Listing Page API.
     /// </summary>
     public class ListingPageAPIOptions
     {
         /// <summary>
-        /// Gets or sets the alias name for the Elasticsearch Collection we will use.
+        /// Gets or sets the alias name for the LabelInformation Elasticsearch Collection we will use.
         /// </summary>
-        /// <value>The name of the alias.</value>
-        public string AliasName { get; set; }
+        /// <value>The name of the LabelInformation alias.</value>
+        public string LabelInformationAliasName { get; set; }
     }
 }

--- a/src/NCI.OCPL.Api.CTSListingPages/NCI.OCPL.Api.CTSListingPages.csproj
+++ b/src/NCI.OCPL.Api.CTSListingPages/NCI.OCPL.Api.CTSListingPages.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
@@ -14,6 +18,8 @@
         <Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.2.2" />
+    <PackageReference Include="NEST" Version="5.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NCI.OCPL.Api.CTSListingPages/Program.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -10,13 +10,22 @@ using Microsoft.Extensions.Logging;
 
 namespace NCI.OCPL.Api.CTSListingPages
 {
+    /// <summary>
+    /// Main program for running the CTS listing page API.
+    /// </summary>
     public class Program
     {
+        /// <summary>
+        /// The main entry point for running the CTS listing page API.
+        /// </summary>
         public static void Main(string[] args)
         {
             CreateWebHostBuilder(args).Build().Run();
         }
 
+        /// <summary>
+        /// CreateWebHostBuilder
+        /// </summary>
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>();

--- a/src/NCI.OCPL.Api.CTSListingPages/Services/ESLabelLookupQueryService.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Services/ESLabelLookupQueryService.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Linq;
+
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
+using Nest;
+
+using System.Threading.Tasks;
+using NCI.OCPL.Api.Common;
+using NCI.OCPL.Api.CTSListingPages.Models;
+
+namespace NCI.OCPL.Api.CTSListingPages.Services
+{
+    /// <summary>
+    /// Elasticsearch implemenation of the service for retrieving label information.
+    /// </summary>
+    public class ESLabelLookupQueryService : ILabelLookupQueryService
+    {
+        /// <summary>
+        /// The elasticsearch client
+        /// </summary>
+        private IElasticClient _elasticClient;
+
+        /// <summary>
+        /// The API options.
+        /// </summary>
+        protected readonly ListingPageAPIOptions _apiOptions;
+
+        /// <summary>
+        /// A logger to use for logging
+        /// </summary>
+        private readonly ILogger<ESLabelLookupQueryService> _logger;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public ESLabelLookupQueryService(IElasticClient client, IOptions<ListingPageAPIOptions> apiOptionsAccessor,
+            ILogger<ESLabelLookupQueryService> logger)
+        {
+            _elasticClient = client;
+            _apiOptions = apiOptionsAccessor.Value;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Retrieve a single LabelInformation with a pretty-url name or identifier exactly matching the name parameter.
+        /// </summary>
+        /// <param name="name">The name - either the pretty-url name or identifier string - of the record to be retrieved.</param>
+        /// <returns>A LabelInformation object or null if an exact match is not found.</returns>
+        public async Task<LabelInformation> Get(string name)
+        {
+            // Set up the SearchRequest to send to elasticsearch.
+            Indices index = Indices.Index(new string[] { this._apiOptions.LabelInformationAliasName });
+            Types types = Types.Type(new string[] { "LabelInformation" });
+            SearchRequest request = new SearchRequest(index, types)
+            {
+                Query = new TermQuery { Field = "pretty_url_name", Value = name.ToString() } ||
+                        new TermQuery { Field = "id_string", Value = name.ToString() }
+            };
+
+            ISearchResponse<LabelInformation> response = null;
+            try
+            {
+                response = await _elasticClient.SearchAsync<LabelInformation>(request);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Error searching index: '{this._apiOptions.LabelInformationAliasName}'.");
+                throw new APIInternalException("errors occured");
+            }
+
+            if (!response.IsValid)
+            {
+                String msg = $"Invalid response when searching for pretty URL name or identifier '{name}'.";
+                _logger.LogError(msg);
+                _logger.LogError(response.DebugInformation);
+                throw new APIInternalException("errors occured");
+            }
+
+            LabelInformation labelInfo = null;
+
+            // If there is are any records in the response, the lookup was successful.
+            if (response.Total > 0)
+            {
+                labelInfo = response.Documents.First();
+
+                if (response.Total > 1)
+                {
+                    _logger.LogWarning($"Found multiple records for pretty URL name or identifier '{name}'.");
+                }
+            }
+
+            return labelInfo;
+        }
+    }
+}

--- a/src/NCI.OCPL.Api.CTSListingPages/Startup.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,9 +12,13 @@ using Microsoft.Extensions.Options;
 
 using NCI.OCPL.Api.Common;
 using NCI.OCPL.Api.CTSListingPages.Models;
+using NCI.OCPL.Api.CTSListingPages.Services;
 
 namespace NCI.OCPL.Api.CTSListingPages
 {
+    /// <summary>
+    /// Defines the configuration of the Listing Page API.
+    /// </summary>
     public class Startup : NciStartupBase
     {
         /// <summary>
@@ -43,7 +47,8 @@ namespace NCI.OCPL.Api.CTSListingPages
         /// <param name="services">Services.</param>
         protected override void AddAppServices(IServiceCollection services)
         {
-            // Add our Query Services
+            // Add our Query Services.
+            services.AddTransient<ILabelLookupQueryService, ESLabelLookupQueryService>();
 
             services.Configure<ListingPageAPIOptions>(Configuration.GetSection("ListingPageAPI"));
         }

--- a/src/NCI.OCPL.Api.CTSListingPages/appsettings.json
+++ b/src/NCI.OCPL.Api.CTSListingPages/appsettings.json
@@ -6,7 +6,8 @@
         "MaximumRetries": 5
     },
     "ListingPageAPI": {
-        "AliasName": "listingpage1"
+        "AliasName": "listingpage1",
+        "LabelInformationAliasName": "labelinformationv1"
     },
     "NSwag": {
         "Title": "CTS Listing Page API",

--- a/src/NCI.OCPL.Api.Common.Testing/TestingTools.cs
+++ b/src/NCI.OCPL.Api.Common.Testing/TestingTools.cs
@@ -1,5 +1,6 @@
-﻿using System.IO;
+using System.IO;
 using System.Reflection;
+using System.Text;
 
 using System.Xml;
 using System.Xml.Serialization;
@@ -7,7 +8,7 @@ using System.Xml.Serialization;
 namespace NCI.OCPL.Api.Common.Testing
 {
     /// <summary>
-    /// Helper tools for loading responses from files and 
+    /// Helper tools for loading responses from files and
     /// deserializing XML to objects.
     /// </summary>
     public static class TestingTools
@@ -42,6 +43,18 @@ namespace NCI.OCPL.Api.Common.Testing
             Stream contents = File.OpenRead(path);
 
             return contents;
+        }
+
+        /// <summary>
+        /// Gets a string as a stream. Useful for when you don't want to maintain a
+        /// separate file but have a string which needs to look like it came from one.
+        /// </summary>
+        /// <param name="dataString">The string to convert.</param>
+        /// <returns></returns>
+        public static Stream GetStringAsStream(string dataString)
+        {
+            byte[] byteArray = Encoding.UTF8.GetBytes(dataString);
+            return new MemoryStream(byteArray);
         }
 
         /// <summary>

--- a/src/NCI.OCPL.Api.Common/APIInternalException.cs
+++ b/src/NCI.OCPL.Api.Common/APIInternalException.cs
@@ -1,0 +1,18 @@
+namespace NCI.OCPL.Api.Common
+{
+    /// <summary>
+    /// Represents an internal error encountered by the API.
+    /// This exception is intended to be thrown by API services and caught by controllers.
+    /// It is **NOT** intended to be returned to the API's consumer.
+    /// </summary>
+    public class APIInternalException : System.Exception
+    {
+        /// <summary>
+        /// Creates a new instance of the APIErrorException
+        /// </summary>
+        /// <param name="message"></param>
+        public APIInternalException(string message) :
+        base(message)
+        { }
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Controllers/LabelLookupControllerTest.Get.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Controllers/LabelLookupControllerTest.Get.cs
@@ -1,0 +1,117 @@
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using Moq;
+using Xunit;
+
+using NCI.OCPL.Api.Common;
+using NCI.OCPL.Api.CTSListingPages.Controllers;
+
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    /// <summary>
+    /// Test the functionality of the Get endpoint of the LabelLookupController.
+    /// </summary>
+    public partial class LabelLookupControllerTest
+    {
+        /// <summary>
+        /// Verify correcting handling of invalid names.
+        /// </summary>
+        [Theory]
+        [InlineData(new object[] { null })]
+        [InlineData(new object[] { "" })]       // Can't use String.Empty because it's a property instead of a constant.
+        [InlineData(new object[] { "    " })]
+        public async void Get_InvalidName(string name)
+        {
+            Mock<ILabelLookupQueryService> querySvc = new Mock<ILabelLookupQueryService>();
+            querySvc.Setup(
+                svc => svc.Get(
+                    It.IsAny<string>()
+                )
+            )
+            .Returns(Task.FromResult(new LabelInformation()));
+
+            LabelLookupController controller = new LabelLookupController(NullLogger<LabelLookupController>.Instance, querySvc.Object);
+
+            var exception = await Assert.ThrowsAsync<APIErrorException>(
+                () => controller.Get(name)
+            );
+
+            querySvc.Verify(
+                svc => svc.Get(It.IsAny<string>()),
+                Times.Never
+            );
+
+            Assert.Equal("You must specify the name parameter.", exception.Message);
+            Assert.Equal(400, exception.HttpStatusCode);
+        }
+
+        /// <summary>
+        /// Verify correct handling of a valid name.
+        /// </summary>
+        [Fact]
+        public async void Get_ValidName()
+        {
+            const string theName = "basic-science";
+
+            LabelInformation testLabelInfo = new LabelInformation
+            {
+                PrettyUrlName = "basic-science",
+                IdString = "basic_science",
+                Label = "Basic Science"
+            };
+
+            Mock<ILabelLookupQueryService> querySvc = new Mock<ILabelLookupQueryService>();
+            querySvc.Setup(
+                svc => svc.Get(
+                    It.IsAny<string>()
+                )
+            )
+            .Returns(Task.FromResult(testLabelInfo));
+
+            // Call the controller.
+            LabelLookupController controller = new LabelLookupController(NullLogger<LabelLookupController>.Instance, querySvc.Object);
+            LabelInformation actual = await controller.Get(theName);
+
+            Assert.Equal(testLabelInfo, actual);
+
+            // Verify the query layer is called:
+            //  a) with the passed value.
+            //  b) exactly once.
+            querySvc.Verify(
+                svc => svc.Get(theName),
+                Times.Once,
+                $"ILabelLookupQueryService:Get() should be called once, with name = '{theName}"
+            );
+
+        }
+
+        /// <summary>
+        /// Verify correct handling of an internal error in the service layer.
+        /// </summary>
+        [Fact]
+        public async void Get_ServiceFailure()
+        {
+            const string theName = "health-services-research";
+
+            Mock<ILabelLookupQueryService> querySvc = new Mock<ILabelLookupQueryService>();
+            querySvc.Setup(
+                svc => svc.Get(
+                    It.IsAny<string>()
+                )
+            )
+            .Throws(new APIInternalException("Kaboom!"));
+
+            // Call the controller, we're not expecting a result, so don't save it.
+            LabelLookupController controller = new LabelLookupController(NullLogger<LabelLookupController>.Instance, querySvc.Object);
+
+            var exception = await Assert.ThrowsAsync<APIErrorException>(
+                () => controller.Get(theName)
+            );
+
+            Assert.Equal("Errors occured.", exception.Message);
+            Assert.Equal(500, exception.HttpStatusCode);
+        }
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Models/LabelInformationComparer.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Models/LabelInformationComparer.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using System.Collections.Generic;
+
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    /// <summary>
+    /// An IEqualityComparer for LabelInformation objects.
+    /// </summary>
+    public class LabelInformationComparer : IEqualityComparer<LabelInformation>
+    {
+        public bool Equals(LabelInformation x, LabelInformation y)
+        {
+            // If the items are both null, or if one or the other is null, return
+            // the correct response right away.
+            if (x == null && y == null)
+            {
+                return true;
+            }
+            else if (x == null || y == null)
+            {
+                return false;
+            }
+
+            bool isEqual =
+                x.PrettyUrlName.Equals(y.PrettyUrlName)
+                && x.IdString.Equals(y.IdString)
+                && x.Label.Equals(y.Label);
+
+            return isEqual;
+        }
+
+        public int GetHashCode(LabelInformation obj)
+        {
+            int hash = 0;
+
+            hash ^=
+                obj.PrettyUrlName.GetHashCode()
+                ^ obj.IdString.GetHashCode()
+                ^ obj.Label.GetHashCode();
+
+            return hash;
+        }
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Services/ESLabelLookupQueryServiceTest.Get.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Services/ESLabelLookupQueryServiceTest.Get.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+using Elasticsearch.Net;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using Moq;
+using Nest;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+using NCI.OCPL.Api.Common;
+using NCI.OCPL.Api.Common.Testing;
+using NCI.OCPL.Api.CTSListingPages.Models;
+using NCI.OCPL.Api.CTSListingPages.Services;
+
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    public partial class ESLabelLookupQueryServiceTest
+    {
+        /// <summary>
+        /// Test to verify that Elasticsearch requests are being assembled correctly.
+        /// </summary>
+        [Fact]
+        public async void Get_TestRequestSetup()
+        {
+            const string theName = "supportive-care";
+            JObject expectedRequest = JObject.Parse(
+@"{
+    ""query"": {
+        ""bool"": {
+            ""should"": [
+                { ""term"": { ""pretty_url_name"": { ""value"": ""supportive-care"" } } },
+                { ""term"": { ""id_string"":       { ""value"": ""supportive-care"" } } }
+            ]
+        }
+    }
+}
+");
+
+            Uri esURI = null;
+            string esContentType = String.Empty;
+            HttpMethod esMethod = HttpMethod.DELETE; // Basically, something other than the expected value.
+
+            JObject requestBody = null;
+
+            ElasticsearchInterceptingConnection conn = new ElasticsearchInterceptingConnection();
+            conn.RegisterRequestHandlerForType<Nest.SearchResponse<LabelInformation>>((req, res) =>
+            {
+                // We don't really care about the response for this test.
+                res.Stream = MockEmptyResponse;
+                res.StatusCode = 200;
+
+                esURI = req.Uri;
+                esContentType = req.ContentType;
+                esMethod = req.Method;
+                requestBody = conn.GetRequestPost(req);
+            });
+
+            // The URI does not matter, an InMemoryConnection never requests from the server.
+            var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+
+            var connectionSettings = new ConnectionSettings(pool, conn);
+            IElasticClient client = new ElasticClient(connectionSettings);
+
+            // Setup the mocked Options
+            IOptions<ListingPageAPIOptions> clientOptions = GetMockOptions();
+
+            ESLabelLookupQueryService query = new ESLabelLookupQueryService(client, clientOptions, new NullLogger<ESLabelLookupQueryService>());
+
+            // For this test, we don't really care that this returns anything, only that the intercepting connection
+            // sets up the request correctly.
+            await query.Get(theName);
+
+            Assert.Equal("/labelinformationv1/LabelInformation/_search", esURI.AbsolutePath);
+            Assert.Equal("application/json", esContentType);
+            Assert.Equal(HttpMethod.POST, esMethod);
+            Assert.Equal(expectedRequest, requestBody, new JTokenEqualityComparer());
+        }
+
+        /// <summary>
+        /// Test failure to connect to ES or receiving an invalid response from ES.
+        /// </summary>
+        [Fact]
+        public async void Get_TestInvalidResponse()
+        {
+            ElasticsearchInterceptingConnection conn = new ElasticsearchInterceptingConnection();
+            conn.RegisterRequestHandlerForType<Nest.SearchResponse<LabelInformation>>((req, res) =>
+            {
+
+            });
+
+            // While this has a URI, it does not matter, an InMemoryConnection never requests
+            // from the server.
+            var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+
+            var connectionSettings = new ConnectionSettings(pool, conn);
+            IElasticClient client = new ElasticClient(connectionSettings);
+
+            // Setup the mocked Options
+            IOptions<ListingPageAPIOptions> clientOptions = GetMockOptions();
+
+            Mock<ILogger<ESLabelLookupQueryService>> _mockLogger = new Mock<ILogger<ESLabelLookupQueryService>>();
+
+            _mockLogger.Setup(log => log.Log(
+                It.IsAny<Microsoft.Extensions.Logging.LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>())
+            );
+
+            ESLabelLookupQueryService queryService = new ESLabelLookupQueryService(client, clientOptions, _mockLogger.Object);
+
+            APIInternalException ex = await Assert.ThrowsAsync<APIInternalException>(() => queryService.Get("chicken"));
+
+            // Verify the correct error message is thrown the correct number of times.
+            _mockLogger.Verify(
+                x => x.Log(
+                    It.Is<Microsoft.Extensions.Logging.LogLevel>(l => l == Microsoft.Extensions.Logging.LogLevel.Error),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString() == "Invalid response when searching for pretty URL name or identifier 'chicken'."),
+                    It.IsAny<Exception>(),
+                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)
+                ),
+                Times.Once
+            );
+            // _mockLogger.Verify(x => x.Log(Microsoft.Extensions.Logging.LogLevel.Error, It.IsAny<Exception>(), "Invalid response when searching for pretty URL name or identifier 'chicken'."), Times.Once);
+        }
+
+        public static IEnumerable<object[]> Get_Success_Scenarios = new[]
+        {
+            new object[] { new Get_NoResults() },
+            new object[] { new Get_SingleResult() },
+            new object[] { new Get_MultipleResults() }
+        };
+
+        /// <summary>
+        /// Test to verify handling when a get request results in no errors (no results, single result, multiple results).
+        /// </summary>
+        [Theory, MemberData(nameof(Get_Success_Scenarios))]
+        public async void Get_TestSuccess(Get_BaseScenario data)
+        {
+            ElasticsearchInterceptingConnection conn = new ElasticsearchInterceptingConnection();
+            conn.RegisterRequestHandlerForType<Nest.SearchResponse<LabelInformation>>((req, res) =>
+            {
+                res.Stream = TestingTools.GetStringAsStream(data.MockESResponse);
+                res.StatusCode = 200;
+            });
+
+            // The URI does not matter, an InMemoryConnection never requests from the server.
+            var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+
+            var connectionSettings = new ConnectionSettings(pool, conn);
+            IElasticClient client = new ElasticClient(connectionSettings);
+
+            // Setup the mocked Options
+            IOptions<ListingPageAPIOptions> clientOptions = GetMockOptions();
+
+            Mock<ILogger<ESLabelLookupQueryService>> _mockLogger = new Mock<ILogger<ESLabelLookupQueryService>>();
+
+            _mockLogger.Setup(log => log.Log(
+                It.IsAny<Microsoft.Extensions.Logging.LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>() )
+            );
+
+            ESLabelLookupQueryService query = new ESLabelLookupQueryService(client, clientOptions, _mockLogger.Object);
+
+            LabelInformation result = await query.Get("treatment");
+
+            // Verify that the logger logs a warning the expected number of times, with the expected error message.
+            // For no results and one result, the logger logs zero warnings with no error message.
+            // For multiple results, the logger logs one warning with the expected error message.
+            _mockLogger.Verify(
+                x => x.Log(
+                    It.Is<Microsoft.Extensions.Logging.LogLevel>(l => l == Microsoft.Extensions.Logging.LogLevel.Warning),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString() == data.ErrorMessage),
+                    It.IsAny<Exception>(),
+                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)
+                ),
+                Times.Exactly(data.ExpectedLoggerCalls)
+            );
+
+            Assert.Equal(data.ExpectedData, result, new LabelInformationComparer());
+        }
+
+        /// <summary>
+        /// Simulates a "no results found" response from Elasticsearch so we
+        /// have something for tests where we don't care about the response.
+        /// </summary>
+        private Stream MockEmptyResponse
+        {
+            get
+            {
+                string empty = @"
+{
+    ""took"": 223,
+    ""timed_out"": false,
+    ""_shards"": {
+        ""total"": 1,
+        ""successful"": 1,
+        ""skipped"": 0,
+        ""failed"": 0
+    },
+    ""hits"": {
+        ""total"": 0,
+        ""max_score"": null,
+        ""hits"": []
+    }
+}";
+                byte[] byteArray = Encoding.UTF8.GetBytes(empty);
+                return new MemoryStream(byteArray);
+            }
+        }
+
+        /// <summary>
+        /// Mock Elasticsearch configuraiton options.
+        /// </summary>
+        private IOptions<ListingPageAPIOptions> GetMockOptions()
+        {
+            Mock<IOptions<ListingPageAPIOptions>> clientOptions = new Mock<IOptions<ListingPageAPIOptions>>();
+            clientOptions
+                .SetupGet(opt => opt.Value)
+                .Returns(new ListingPageAPIOptions()
+                {
+                    LabelInformationAliasName = "labelinformationv1"
+                }
+            );
+
+            return clientOptions.Object;
+        }
+
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESLabelLookupQueryService/Get_BaseScenario.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESLabelLookupQueryService/Get_BaseScenario.cs
@@ -1,0 +1,26 @@
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    public abstract class Get_BaseScenario
+    {
+        /// <summary>
+        /// The mock response from Elasticsearch.
+        /// </summary>
+        /// <value></value>
+        public abstract string MockESResponse { get; }
+
+        /// <summary>
+        /// The LabelInformation which the service is expected to return from the response.
+        /// </summary>
+        public abstract LabelInformation ExpectedData { get; }
+
+        /// <summary>
+        /// The error message which the service is expected to log.
+        /// </summary>
+        public abstract string ErrorMessage { get; }
+
+        /// <summary>
+        /// The number of times the service is expected to log an error message.
+        /// </summary>
+        public abstract int ExpectedLoggerCalls { get; }
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESLabelLookupQueryService/Get_MultipleResults.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESLabelLookupQueryService/Get_MultipleResults.cs
@@ -1,0 +1,58 @@
+using Moq;
+
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    class Get_MultipleResults : Get_BaseScenario
+    {
+        public override string MockESResponse => @"
+{
+    ""took"": 20,
+    ""timed_out"": false,
+    ""_shards"": {
+        ""total"": 1,
+        ""successful"": 1,
+        ""skipped"": 0,
+        ""failed"": 0
+    },
+    ""hits"": {
+        ""total"": 2,
+        ""max_score"": 2.2335923,
+        ""hits"": [
+            {
+                ""_index"": ""labelinformationv1"",
+                ""_type"": ""LabelInformation"",
+                ""_id"": ""AXUtWHSZPZ7BGoClhnsQ"",
+                ""_score"": 2.2335923,
+                ""_source"": {
+                    ""pretty_url_name"": ""treatment"",
+                    ""id_string"": ""treatment"",
+                    ""label"": ""Treatment""
+                }
+            },
+            {
+                ""_index"": ""labelinformationv1"",
+                ""_type"": ""LabelInformation"",
+                ""_id"": ""AXUtWHSZPZ7BGoClhnsQ"",
+                ""_score"": 2.2335923,
+                ""_source"": {
+                    ""pretty_url_name"": ""treatment"",
+                    ""id_string"": ""treatment"",
+                    ""label"": ""Treatment""
+                }
+            },
+        ]
+    }
+}";
+
+        public override LabelInformation ExpectedData => new LabelInformation
+        {
+            PrettyUrlName = "treatment",
+            IdString = "treatment",
+            Label = "Treatment"
+        };
+
+        public override string ErrorMessage => "Found multiple records for pretty URL name or identifier 'treatment'.";
+
+        public override int ExpectedLoggerCalls => 1;
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESLabelLookupQueryService/Get_NoResults.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESLabelLookupQueryService/Get_NoResults.cs
@@ -1,0 +1,30 @@
+using Moq;
+
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    class Get_NoResults : Get_BaseScenario
+    {
+        public override string MockESResponse => @"
+{
+    ""took"": 223,
+    ""timed_out"": false,
+    ""_shards"": {
+        ""total"": 1,
+        ""successful"": 1,
+        ""skipped"": 0,
+        ""failed"": 0
+    },
+    ""hits"": {
+        ""total"": 0,
+        ""max_score"": null,
+        ""hits"": []
+    }
+}";
+
+        public override LabelInformation ExpectedData => null;
+
+        public override string ErrorMessage => null;
+
+        public override int ExpectedLoggerCalls => 0;
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESLabelLookupQueryService/Get_SingleResult.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESLabelLookupQueryService/Get_SingleResult.cs
@@ -1,0 +1,47 @@
+using Moq;
+
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    class Get_SingleResult : Get_BaseScenario
+    {
+        public override string MockESResponse => @"
+{
+    ""took"": 20,
+    ""timed_out"": false,
+    ""_shards"": {
+        ""total"": 1,
+        ""successful"": 1,
+        ""skipped"": 0,
+        ""failed"": 0
+    },
+    ""hits"": {
+        ""total"": 1,
+        ""max_score"": 2.2335923,
+        ""hits"": [
+            {
+                ""_index"": ""labelinformationv1"",
+                ""_type"": ""LabelInformation"",
+                ""_id"": ""AXUtWHSZPZ7BGoClhnsQ"",
+                ""_score"": 2.2335923,
+                ""_source"": {
+                    ""pretty_url_name"": ""treatment"",
+                    ""id_string"": ""treatment"",
+                    ""label"": ""Treatment""
+                }
+            }
+        ]
+    }
+}";
+
+        public override LabelInformation ExpectedData => new LabelInformation
+        {
+            PrettyUrlName = "treatment",
+            IdString = "treatment",
+            Label = "Treatment"
+        };
+
+        public override string ErrorMessage => null;
+
+        public override int ExpectedLoggerCalls => 0;
+    }
+}


### PR DESCRIPTION
* Add LabelLookup Controller with Get method
* Add ILabelLookupQueryService interface with Get method
* Add ESLabelLookupQueryService implementation with Get method
* Add LabelInformationAliasName to API Options model
* Add LabelInformationAliasName to appsettings
* Add LabelLookupController tests for Get method
* Add ESLabelLookupQueryService tests for Get method
* Add test data for ESLabelLookupQueryService tests for Get method
* Add LabelInformation comparer
* Add APIInternalException
* Add GetStringAsStream in TestingTools
* Add integration tests for LabelLookup Controller Get method