### PR TITLE
(#34) Prevent record return when not all c-codes present.

### DIFF
--- a/integration-tests/features/listing-information/getByIds/errors-excess-code.json
+++ b/integration-tests/features/listing-information/getByIds/errors-excess-code.json
@@ -1,0 +1,3 @@
+{
+    "Message": "Could not find codes 'C115332,C7705,C3359,C9130,C0001'."
+}

--- a/integration-tests/features/listing-information/getByIds/errors-partially-overlapping-codes.json
+++ b/integration-tests/features/listing-information/getByIds/errors-partially-overlapping-codes.json
@@ -1,0 +1,3 @@
+{
+    "Message": "Could not find codes 'C115332,C7705,C0001'."
+}

--- a/integration-tests/features/listing-information/getByIds/errors.feature
+++ b/integration-tests/features/listing-information/getByIds/errors.feature
@@ -1,10 +1,10 @@
-Feature: Fail to retrieve listing information when searching for c-code(s) associated with multiple records.
+Feature: Expected failures
 
     Background:
         * url apiHost
 
     Scenario Outline: Validate no result found when matching against c-code(s) returning multiple records.
-
+        for code list: <code>, expect status <exStatus>
 
         Given path 'listing-information', 'get'
         And params { ccode: <code> }
@@ -20,3 +20,18 @@ Feature: Fail to retrieve listing information when searching for c-code(s) assoc
             | 404       | ['C0000', 'C0001']  | errors-multiple-nonexistent-codes.json             |
             | 409       | C7707               | errors-multiple-soft-tissue-sarcoma.json           |
             | 409       | C7884               | errors-multiple-recurrent-brain-neoplasm.json      |
+
+
+    Scenario Outline: Validate no result returned when request contains a c-code not found in the record.
+        for code list: <code>, expect status <exStatus>
+
+        Given path 'listing-information', 'get'
+        And params { ccode: <code> }
+        When method get
+        Then assert responseStatus == exStatus
+        And match response == read( expected )
+
+        Examples:
+            | exStatus  | code                                              | expected                                  |
+            | 404       | ['C115332', 'C7705', 'C3359', 'C9130', 'C0001']   | errors-excess-code.json                   |
+            | 404       | ['C115332', 'C7705', 'C0001']                     | errors-partially-overlapping-codes.json   |

--- a/src/NCI.OCPL.Api.CTSListingPages/Services/ESListingInfoQueryService.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Services/ESListingInfoQueryService.cs
@@ -129,21 +129,49 @@ namespace NCI.OCPL.Api.CTSListingPages.Services
 
             ListingInfo[] results = null;
 
+            // As of Elaticsearch v5.6.x, the terms query only tells us that there's an *overlap* between the requested
+            // list of c-codes and the ones which are actually present in the records. ES 7 adds the ability to specify
+            // a minimum amount of overlap (e.g. "the entire set I asked for"), but we don't have that yet. Instead,
+            // we have to add a step to remove the mismatch.  The way the loader is supposed to work, there should be
+            // no case of the same c-code appear in multiple records. Therefore, if anything matches, there should be
+            // at most one record.  So, if we find any record where not all requested codes are present, we discard
+            // the entire set.  Because "the entire set" is only supposed to be one record anyhow.
+
             // If there is one or more items in the response, the lookup was successful.
             if (response.Total > 0)
             {
-                // Set the ListingInfo[] results to the returned documents.
-                results = response.Documents.ToArray();
-
-                // If there are more than one items in the response, long a warning. The controller will handle the error.
-                if (response.Total > 1)
+                if(response.Documents.All(item => AllRequestedCodesPresent(ccodes, item.ConceptId)))
                 {
-                    String msg = $"Multiple records found when searching for c-code(s) '{String.Join(",", ccodes)}'.";
-                    _logger.LogWarning(msg);
+                    // Set the ListingInfo[] results to the returned documents.
+                    results = response.Documents.ToArray();
                 }
             }
 
             return results;
+        }
+
+        /// <summary>
+        /// Helper method to verify that the set of codes requested is a subset of the list of
+        /// codes in a given record.
+        /// </summary>
+        /// <param name="requested">The requested list of c-codes</param>
+        /// <param name="actual">The actual list of c-codes</param>
+        /// <returns></returns>
+        public static bool AllRequestedCodesPresent(string[] requested, string[] actual)
+        {
+            // Simple case.
+            if(requested.Length > actual.Length)
+                return false;
+
+            // Create a hashset with uppercase version of all the actal codes.
+            HashSet<string> knownCodes = new HashSet<string>(
+                from code in actual select code.ToUpper()
+            );
+
+            // Check whether all codes from the requested list are in the known list.
+            bool allFound = requested.All(code => knownCodes.Contains(code.ToUpper()));
+
+            return allFound;
         }
     }
 }

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Services/ESListingInfoQueryServiceTest.AllRequestedCodesPresent.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Services/ESListingInfoQueryServiceTest.AllRequestedCodesPresent.cs
@@ -1,0 +1,40 @@
+using Xunit;
+
+using NCI.OCPL.Api.CTSListingPages.Services;
+
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    public partial class ESListingInfoQueryServiceTest
+    {
+        /// <summary>
+        /// Verify the AllRequestedCodesPresent helper method returns correctly when all requested codes
+        /// are present.
+        /// </summary>
+        [Theory]
+        [InlineData(new string[] { "C123" }, new string[] { "C123" })] // One code
+        [InlineData(new string[] { "C123", "C456", "C789" }, new string[] { "C123", "C456", "C789" })] // Multiple codes
+        [InlineData(new string[] { "C123" }, new string[] { "C123", "C456", "C789" })] // Subset of codes
+        [InlineData(new string[] { "C456", "C789" }, new string[] { "C123", "C456", "C789" })] // Subset of codes
+        public void AllRequestedCodesPresent_AllValid(string[] requested, string[] actual)
+        {
+            bool result = ESListingInfoQueryService.AllRequestedCodesPresent(requested, actual);
+            Assert.True(result);
+        }
+
+        /// <summary>
+        /// Verify the AllRequestedCodesPresent helper method returns correctly when all requested codes
+        /// are missing from the actual.
+        /// </summary>
+        [Theory]
+        [InlineData(new string[] { "C123", "C456", "C789" }, new string[] { "C123" })] // More codes than data
+        [InlineData(new string[] { "C123", "C456", "C789" }, new string[] { "C123", "C789" })] // More codes than data
+        [InlineData(new string[] { "C123" }, new string[] { "C456" })] // Code not present
+        [InlineData(new string[] { "C456", "C789" }, new string[] { "C123", "C456" })] // Multiple codes
+        [InlineData(new string[] { "C123", "C456", "C789" }, new string[] { "C123", "C456" })] // All but one present
+        public void AllRequestedCodesPresent_MissingCodes(string[] requested, string[] actual)
+        {
+            bool result = ESListingInfoQueryService.AllRequestedCodesPresent(requested, actual);
+            Assert.False(result);
+        }
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_BaseScenario.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_BaseScenario.cs
@@ -5,19 +5,18 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
     public abstract class GetByIds_BaseScenario
     {
         /// <summary>
+        /// The list of CCodes to pass into the query.
+        /// </summary>
+        public abstract string[] InputCCodes {get;}
+
+        /// <summary>
         /// The mock response from Elasticsearch.
         /// </summary>
-        /// <value></value>
         public abstract string MockESResponse {get;}
 
         /// <summary>
         /// The ListingResults object which the service is expected to return from the response.
         /// </summary>
         public abstract ListingInfo[] ExpectedData { get; }
-
-        /// <summary>
-        /// The number of times logging is expected to occur.
-        /// </summary>
-        public abstract int ExpectedNumberOfLoggingCalls { get; }
     }
 }

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_ExcessCodes.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_ExcessCodes.cs
@@ -1,8 +1,12 @@
 namespace NCI.OCPL.Api.CTSListingPages.Tests
 {
-    class GetByIds_SingleResult : GetByIds_BaseScenario
+    /// <summary>
+    /// Test for a request with more c-codes than are in the response.
+    /// </summary>
+    class GetByIds_ExcessCodes : GetByIds_BaseScenario
     {
-        public override string[] InputCCodes => new string[] { "C8578", "C115270" };
+        // C12345 is "extra"
+        public override string[] InputCCodes => new string[] { "C115270", "C8578", "C9092", "C3017", "C12345"};
 
         public override string MockESResponse => @"
 {
@@ -42,16 +46,6 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
     }
 }";
 
-        public override ListingInfo[] ExpectedData => new ListingInfo[] {
-            new ListingInfo {
-                ConceptId = new string[] { "C115270", "C8578", "C9092", "C3017" },
-                Name = new NameInfo
-                {
-                    Label = "Ependymoma",
-                    Normalized = "ependymoma"
-                },
-                PrettyUrlName = "ependymoma"
-            }
-        };
+        public override ListingInfo[] ExpectedData => null;
     }
 }

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_MultipleResults.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_MultipleResults.cs
@@ -5,6 +5,8 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
     /// </summary>
     class GetByIds_MultipleResults : GetByIds_BaseScenario
     {
+        public override string[] InputCCodes => new string[] { "C4872" };
+
         public override string MockESResponse => @"
 {
     ""took"": 20,
@@ -76,7 +78,5 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
                 PrettyUrlName = "breast-cancer"
             }
         };
-
-        public override int ExpectedNumberOfLoggingCalls => 1;
     }
 }

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_NoResults.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_NoResults.cs
@@ -2,6 +2,8 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
 {
     class GetByIds_NoResults : GetByIds_BaseScenario
     {
+        public override string[] InputCCodes => new string[] {"C1234"};
+
         public override string MockESResponse => @"
 {
     ""took"": 223,
@@ -20,7 +22,5 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
 }";
 
         public override ListingInfo[] ExpectedData => null;
-
-        public override int ExpectedNumberOfLoggingCalls => 0;
     }
 }

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_OverlappingCodes.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_OverlappingCodes.cs
@@ -1,8 +1,13 @@
 namespace NCI.OCPL.Api.CTSListingPages.Tests
 {
-    class GetByIds_SingleResult : GetByIds_BaseScenario
+    /// <summary>
+    /// Test handling for a request with fewer c-codes than the response, but
+    /// has one the response does not.
+    /// </summary>
+    class GetByIds_OverlappingCodes : GetByIds_BaseScenario
     {
-        public override string[] InputCCodes => new string[] { "C8578", "C115270" };
+        // C12345 is "extra"
+        public override string[] InputCCodes => new string[] { "C9092", "C12345", "C3017"};
 
         public override string MockESResponse => @"
 {
@@ -42,16 +47,6 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
     }
 }";
 
-        public override ListingInfo[] ExpectedData => new ListingInfo[] {
-            new ListingInfo {
-                ConceptId = new string[] { "C115270", "C8578", "C9092", "C3017" },
-                Name = new NameInfo
-                {
-                    Label = "Ependymoma",
-                    Normalized = "ependymoma"
-                },
-                PrettyUrlName = "ependymoma"
-            }
-        };
+        public override ListingInfo[] ExpectedData => null;
     }
 }

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_OverlappingCodesMultipleRecords.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_OverlappingCodesMultipleRecords.cs
@@ -1,0 +1,79 @@
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    /// <summary>
+    /// Test for multiple records found, the first of which does not have all the c-codes
+    /// from the requests.
+    ///
+    /// This is expected to return no records as ideally the service would never find multiple records
+    /// matching the same c-codes and reacts to finding one missing by throwing out all the records
+    /// because "all the records" should only be one in the first place.
+    ///
+    /// (See comments in ESListingInfoQueryService::GetByIds for more details.)
+    /// </summary>
+    class GetByIds_OverlappingCodesMultipleRecords : GetByIds_BaseScenario
+    {
+        // C8578 is missing from the first record, present in the second.
+        public override string[] InputCCodes => new string[] { "C115270", "C8578", "C9092"};
+
+        public override string MockESResponse => @"
+{
+    ""took"": 20,
+    ""timed_out"": false,
+    ""_shards"": {
+        ""total"": 1,
+        ""successful"": 1,
+        ""skipped"": 0,
+        ""failed"": 0
+    },
+    ""hits"": {
+        ""total"": 1,
+        ""max_score"": 2.2335923,
+        ""hits"": [
+            {
+                ""_index"": ""listinginfov1"",
+                ""_type"": ""ListingInfo"",
+                ""_id"": ""AXUtWHSZPZ7BGoClhnsQ"",
+                ""_score"": 2.2335923,
+                ""_source"": {
+                    ""type"": ""OverrideRecord"",
+                    ""concept_id"": [
+                        ""C115270"",
+                        ""C9092"",
+                        ""C3017""
+                    ],
+                    ""name"": {
+                        ""label"": ""Ependymoma"",
+                        ""normalized"": ""ependymoma""
+                    },
+                    ""pretty_url_name"": ""ependymoma""
+                }
+            },
+            {
+                ""_index"": ""listinginfov1"",
+                ""_type"": ""ListingInfo"",
+                ""_id"": ""AXf-DxRKzojRwC-tFiLm"",
+                ""_score"": null,
+                ""_source"": {
+                    ""concept_id"": [
+                        ""C115270"",
+                        ""C8578"",
+                        ""C9092"",
+                        ""C3017""
+                    ],
+                    ""name"": {
+                        ""label"": ""Rhabdomyosarcoma"",
+                        ""normalized"": ""rhabdomyosarcoma""
+                    },
+                    ""pretty_url_name"": ""rhabdomyosarcoma""
+                },
+                ""sort"": [
+                    ""rhabdomyosarcoma""
+                ]
+            }
+        ]
+    }
+}";
+
+        public override ListingInfo[] ExpectedData => null;
+    }
+}

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_OverlappingCodesMultipleRecords2.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_OverlappingCodesMultipleRecords2.cs
@@ -1,0 +1,79 @@
+namespace NCI.OCPL.Api.CTSListingPages.Tests
+{
+    /// <summary>
+    /// Test for multiple records found, the second of which does not have all the c-codes
+    /// from the requests.
+    ///
+    /// This is expected to return no records as ideally the service would never find multiple records
+    /// matching the same c-codes and reacts to finding one missing by throwing out all the records
+    /// because "all the records" should only be one in the first place.
+    ///
+    /// (See comments in ESListingInfoQueryService::GetByIds for more details.)
+    /// </summary>
+    class GetByIds_OverlappingCodesMultipleRecords2 : GetByIds_BaseScenario
+    {
+        // C8578 is present in the first record, missing from the second.
+        public override string[] InputCCodes => new string[] { "C115270", "C8578", "C9092"};
+
+        public override string MockESResponse => @"
+{
+    ""took"": 20,
+    ""timed_out"": false,
+    ""_shards"": {
+        ""total"": 1,
+        ""successful"": 1,
+        ""skipped"": 0,
+        ""failed"": 0
+    },
+    ""hits"": {
+        ""total"": 2,
+        ""max_score"": 2.2335923,
+        ""hits"": [
+            {
+                ""_index"": ""listinginfov1"",
+                ""_type"": ""ListingInfo"",
+                ""_id"": ""AXUtWHSZPZ7BGoClhnsQ"",
+                ""_score"": 2.2335923,
+                ""_source"": {
+                    ""type"": ""OverrideRecord"",
+                    ""concept_id"": [
+                        ""C115270"",
+                        ""C8578"",
+                        ""C9092"",
+                        ""C3017""
+                    ],
+                    ""name"": {
+                        ""label"": ""Ependymoma"",
+                        ""normalized"": ""ependymoma""
+                    },
+                    ""pretty_url_name"": ""ependymoma""
+                }
+            },
+            {
+                ""_index"": ""listinginfov1"",
+                ""_type"": ""ListingInfo"",
+                ""_id"": ""AXf-DxRKzojRwC-tFiLm"",
+                ""_score"": null,
+                ""_source"": {
+                    ""concept_id"": [
+                        ""C115270"",
+                        ""C9092"",
+                        ""C3017""
+                    ],
+                    ""name"": {
+                        ""label"": ""Rhabdomyosarcoma"",
+                        ""normalized"": ""rhabdomyosarcoma""
+                    },
+                    ""pretty_url_name"": ""rhabdomyosarcoma""
+                },
+                ""sort"": [
+                    ""rhabdomyosarcoma""
+                ]
+            }
+        ]
+    }
+}";
+
+        public override ListingInfo[] ExpectedData => null;
+    }
+}


### PR DESCRIPTION
- Add logic to ESListingInfoQueryService::GetByIds to eliminate results when not all c-codes are present (emulate behavior ES 5.6 doesn't offer).
- Remove logging logic from GetByIds which duplicates report in the controller.
- Refactor GetByIds_TestValidResponse and related classes to eliminate hard-coded test parameter.
- Many tests.

Close #34 