### PR TITLE
(#38) Update Elasticsearch NEST to v7.9.0.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -71,7 +71,10 @@ jobs:
     needs: test_build_release
     services:
       elasticsearch:
-        image: elasticsearch:5.6.16
+        image: elasticsearch:7.9.2
+        env:
+          ## Pass elasticsearch options via environment variables.
+          discovery.type: single-node
         ports:
           ## NOTE: This will be exposed as a random port referenced below by job.services.elasticsearch.ports[9200]
           - 9200/tcp

--- a/integration-tests/data/source/listing-info-es-mapping.json
+++ b/integration-tests/data/source/listing-info-es-mapping.json
@@ -17,31 +17,27 @@
         }
     },
     "mappings": {
-        "ListingInfo": {
-            "_all": {
-                "enabled": false
+        "dynamic": "strict",
+        "properties": {
+            "concept_id": {
+                "type": "keyword",
+                "normalizer": "caseinsensitive_normalizer"
             },
-            "properties": {
-                "concept_id": {
-                    "type": "keyword",
-                    "normalizer": "caseinsensitive_normalizer"
-                },
-                "name": {
-                    "properties": {
-                        "label": {
-                            "type": "keyword",
-                            "normalizer": "caseinsensitive_normalizer"
-                        },
-                        "normalized": {
-                            "type": "keyword",
-                            "normalizer": "caseinsensitive_normalizer"
-                        }
+            "name": {
+                "properties": {
+                    "label": {
+                        "type": "keyword",
+                        "normalizer": "caseinsensitive_normalizer"
+                    },
+                    "normalized": {
+                        "type": "keyword",
+                        "normalizer": "caseinsensitive_normalizer"
                     }
-                },
-                "pretty_url_name": {
-                    "type": "keyword",
-                    "normalizer": "caseinsensitive_normalizer"
                 }
+            },
+            "pretty_url_name": {
+                "type": "keyword",
+                "normalizer": "caseinsensitive_normalizer"
             }
         }
     }

--- a/integration-tests/data/source/trial-type-info-data.jsonl
+++ b/integration-tests/data/source/trial-type-info-data.jsonl
@@ -1,16 +1,16 @@
-{"index": {"_index": "trialtypeinfov1", "_type": "TrialTypeInfo"}}
+{"index": {"_index": "trialtypeinfov1"}}
 {"pretty_url_name": "treatment", "id_string": "treatment", "label": "Treatment"}
-{"index": {"_index": "trialtypeinfov1", "_type": "TrialTypeInfo"}}
+{"index": {"_index": "trialtypeinfov1"}}
 {"pretty_url_name": "other", "id_string": "other", "label": "Other"}
-{"index": {"_index": "trialtypeinfov1", "_type": "TrialTypeInfo"}}
+{"index": {"_index": "trialtypeinfov1"}}
 {"pretty_url_name": "supportive-care", "id_string": "supportive_care", "label": "Supportive Care"}
-{"index": {"_index": "trialtypeinfov1", "_type": "TrialTypeInfo"}}
+{"index": {"_index": "trialtypeinfov1"}}
 {"pretty_url_name": "diagnostic", "id_string": "diagnostic", "label": "Diagnostic"}
-{"index": {"_index": "trialtypeinfov1", "_type": "TrialTypeInfo"}}
+{"index": {"_index": "trialtypeinfov1"}}
 {"pretty_url_name": "prevention", "id_string": "prevention", "label": "Prevention"}
-{"index": {"_index": "trialtypeinfov1", "_type": "TrialTypeInfo"}}
+{"index": {"_index": "trialtypeinfov1"}}
 {"pretty_url_name": "basic-science", "id_string": "basic_science", "label": "Basic Science"}
-{"index": {"_index": "trialtypeinfov1", "_type": "TrialTypeInfo"}}
+{"index": {"_index": "trialtypeinfov1"}}
 {"pretty_url_name": "health-services-research", "id_string": "health_services_research", "label": "Health Services Research"}
-{"index": {"_index": "trialtypeinfov1", "_type": "TrialTypeInfo"}}
+{"index": {"_index": "trialtypeinfov1"}}
 {"pretty_url_name": "screening", "id_string": "screening", "label": "Screening"}

--- a/integration-tests/data/source/trial-type-info-es-mapping.json
+++ b/integration-tests/data/source/trial-type-info-es-mapping.json
@@ -17,18 +17,18 @@
         }
     },
     "mappings": {
-        "TrialTypeInfo": {
-            "_all":         { "enabled": false },
-            "properties":   {
-                "pretty_url_name":  {
-                                        "type": "keyword",
-                                        "normalizer": "caseinsensitive_normalizer"
-                                    },
-                "id_string":        {
-                                        "type": "keyword",
-                                        "normalizer": "caseinsensitive_normalizer"
-                                    },
-                "label":            { "type": "keyword"    }
+        "dynamic": "strict",
+        "properties": {
+            "pretty_url_name": {
+                "type": "keyword",
+                "normalizer": "caseinsensitive_normalizer"
+            },
+            "id_string": {
+                "type": "keyword",
+                "normalizer": "caseinsensitive_normalizer"
+            },
+            "label": {
+                "type": "keyword"
             }
         }
     }

--- a/integration-tests/docker-cts-listing-page-api/api/Dockerfile
+++ b/integration-tests/docker-cts-listing-page-api/api/Dockerfile
@@ -13,7 +13,7 @@ COPY ./integration-tests/docker-cts-listing-page-api/api/build/appsettings.intte
 COPY ./integration-tests/docker-cts-listing-page-api/api/build/hosting.json .
 ## This does not need to wait for the loader or other resources.
 ## Any integration tests will need to wait for the API to report being healthy
-EXPOSE 5001
+EXPOSE 5000
 ENV ASPNETCORE_ENVIRONMENT=inttest
 ENV ASPNETCORE_URLS="http://*:5000"
 ENTRYPOINT ["dotnet", "NCI.OCPL.Api.CTSListingPages.dll"]

--- a/integration-tests/docker-cts-listing-page-api/docker-compose.yml
+++ b/integration-tests/docker-cts-listing-page-api/docker-compose.yml
@@ -2,12 +2,11 @@ version: "3.7"
 
 services:
     elasticsearch:
-        image: elasticsearch:5.6.16
+        image: elasticsearch:7.9.2
         ## All of the ES settings can be set via the environment
         ## vars.
         environment:
-            - discovery.zen.ping.unicast.hosts=["127.0.0.1"]
-            - discovery.zen.minimum_master_nodes=1
+            - discovery.type=single-node
             - ES_JAVA_OPTS=-Xms750m -Xmx750m
         ## These exposed ports are for debugging only. .NET +
         ## Docker + MacOS == bad scene. (.NET always wants to

--- a/integration-tests/features/listing-information/getByIds/id-found-rhabdomyosarcoma.json
+++ b/integration-tests/features/listing-information/getByIds/id-found-rhabdomyosarcoma.json
@@ -2,7 +2,8 @@
     "conceptId": [
         "C3359",
         "C7705",
-        "C9130"
+        "C9130",
+        "C115332"
     ],
     "name": {
         "label": "Rhabdomyosarcoma",

--- a/src/NCI.OCPL.Api.CTSListingPages/NCI.OCPL.Api.CTSListingPages.csproj
+++ b/src/NCI.OCPL.Api.CTSListingPages/NCI.OCPL.Api.CTSListingPages.csproj
@@ -19,7 +19,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="NSwag.AspNetCore" Version="13.2.2" />
-    <PackageReference Include="NEST" Version="5.6.1" />
+    <PackageReference Include="NEST" Version="7.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NCI.OCPL.Api.CTSListingPages/Services/ESListingInfoQueryService.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Services/ESListingInfoQueryService.cs
@@ -52,8 +52,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Services
         {
             // Set up the SearchRequest to send to elasticsearch.
             Indices index = Indices.Index(new string[] { this._apiOptions.ListingInfoAliasName });
-            Types types = Types.Type(new string[] { "ListingInfo" });
-            SearchRequest request = new SearchRequest(index, types)
+            SearchRequest request = new SearchRequest(index)
             {
                 Query = new TermQuery { Field = "pretty_url_name", Value = prettyUrlName.ToString() }
             };
@@ -102,8 +101,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Services
         {
             // Set up the SearchRequest to send to elasticsearch.
             Indices index = Indices.Index(new string[] { this._apiOptions.ListingInfoAliasName });
-            Types types = Types.Type(new string[] { "ListingInfo" });
-            SearchRequest request = new SearchRequest(index, types)
+            SearchRequest request = new SearchRequest(index)
             {
                 Query = new TermsQuery { Field = "concept_id", Terms = ccodes }
             };

--- a/src/NCI.OCPL.Api.CTSListingPages/Services/ESTrialTypeQueryService.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Services/ESTrialTypeQueryService.cs
@@ -51,8 +51,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Services
         {
             // Set up the SearchRequest to send to elasticsearch.
             Indices index = Indices.Index(new string[] { this._apiOptions.TrialTypeInfoAliasName });
-            Types types = Types.Type(new string[] { "TrialTypeInfo" });
-            SearchRequest request = new SearchRequest(index, types)
+            SearchRequest request = new SearchRequest(index)
             {
                 Query = new TermQuery { Field = "pretty_url_name", Value = name.ToString() } ||
                         new TermQuery { Field = "id_string", Value = name.ToString() }
@@ -79,7 +78,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Services
 
             TrialTypeInfo trialTypeInfo = null;
 
-            // If there is are any records in the response, the lookup was successful.
+            // If there are any records in the response, the lookup was successful.
             if (response.Total > 0)
             {
                 trialTypeInfo = response.Documents.First();

--- a/src/NCI.OCPL.Api.Common.Testing/ElasticsearchInterceptingConnection.cs
+++ b/src/NCI.OCPL.Api.Common.Testing/ElasticsearchInterceptingConnection.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
@@ -11,30 +10,57 @@ using Newtonsoft.Json.Linq;
 
 namespace NCI.OCPL.Api.Common.Testing
 {
+    /// <summary>
+    /// Provides a simulated Elasticsearch connection object for use in testing.
+    /// </summary>
+    /// <remarks>
+    /// Use <see cref="RegisterRequestHandlerForType" /> to set simulated Elasticsearch responses.
+    /// </remarks>
     public class ElasticsearchInterceptingConnection : IConnection
     {
+        /// <summary>
+        /// Container for simulated Elasticsearch responses.
+        /// </summary>
+        public class ResponseData
+        {
+            /// <summary>
+            /// Stream representing the response body.
+            /// </summary>
+            public Stream Stream { get; set; }
+
+            /// <summary>
+            /// The simulated Elasticsearch HTTP status code.  Required if Stream is set.
+            /// </summary>
+            public int? StatusCode { get; set; }
+
+            /// <summary>
+            /// The simulated response MIME type.
+            /// </summary>
+            public string ResponseMimeType { get; set; }
+        }
+
         private Dictionary<Type, object> _callbackHandlers = new Dictionary<Type, object>();
         private Action<RequestData, object> _defCallbackHandler = null;
 
         public void Dispose()
         {
-            
+
         }
 
         /// <summary>
-        /// Register a Request Handler for a Given return type.
+        /// Register a Request Handler for a given return type.
         /// NOTE: DO NOT REGISTER BOTH A CLASS AND ITS BASE CLASS!!!
         /// </summary>
         /// <typeparam name="TReturn"></typeparam>
         /// <param name="callback"></param>
-        public void RegisterRequestHandlerForType<TReturn>(Action<RequestData, ResponseBuilder<TReturn>> callback)
+        public void RegisterRequestHandlerForType<TReturn>(Action<RequestData, ResponseData> callback)
             where TReturn : class
         {
             Type returnType = typeof(TReturn);
             Type handlerType = null;
 
             //Loop through the register handlers and see if our type is registered, OR
-            //if a base class is registered.  
+            //if a base class is registered.
             foreach (Type type in _callbackHandlers.Keys)
             {
                 if (returnType == type || returnType.GetTypeInfo().IsSubclassOf(type))
@@ -68,27 +94,27 @@ namespace NCI.OCPL.Api.Common.Testing
             this._defCallbackHandler = callback;
         }
 
-        private void ProcessRequest<TReturn>(RequestData requestData, ResponseBuilder<TReturn> builder)
+        private void ProcessRequest<TReturn>(RequestData requestData, ResponseData responseData)
             where TReturn : class
         {
             Type returnType = typeof(TReturn);
-            bool foundHandler = false;
+                bool foundHandler = false;
 
-            //Loop through the register handlers and see if our type is registered, OR
-            //if a base class is registered.  
-            foreach (Type type in _callbackHandlers.Keys)
-            {
-                if (returnType == type || returnType.GetTypeInfo().IsSubclassOf(type))
+                // Loop through the register handlers and see if our type is registered, OR
+                // if a base class is registered.
+                foreach (Type type in _callbackHandlers.Keys)
                 {
-                    foundHandler = true;
+                    if (returnType == type || returnType.GetTypeInfo().IsSubclassOf(type))
+                    {
+                        foundHandler = true;
 
-                    Action<RequestData, ResponseBuilder<TReturn>> callback =
-                        (Action<RequestData, ResponseBuilder<TReturn>>)_callbackHandlers[typeof(TReturn)];
+                        Action<RequestData, ResponseData> callback =
+                            (Action<RequestData, ResponseData>)_callbackHandlers[typeof(TReturn)];
 
-                    callback(
-                        requestData,
-                        builder
-                    );
+                        callback(
+                            requestData,
+                            responseData
+                        );
 
                     break;
                 }
@@ -100,7 +126,7 @@ namespace NCI.OCPL.Api.Common.Testing
                 foundHandler = true;
                 _defCallbackHandler(
                     requestData,
-                    builder
+                    responseData
                 );
             }
 
@@ -110,45 +136,75 @@ namespace NCI.OCPL.Api.Common.Testing
 
             //It looks like, based on the code and use of the code, not because of actual commeents, that MadeItToResponse gets set
             //once the Connection was able to get a response from a server.  I am going to set it here, but we may need to update later
-            //if we want to test connection failures. 
+            //if we want to test connection failures.
             requestData.MadeItToResponse = true;
+
+            // If the dev writing the test DID provide response data, but DID NOT set a MIME type, we'll just have to
+            // assume they meant to set "applicaton/json" since that's what Elasticsearch normally sends back.
+            if (String.IsNullOrWhiteSpace(responseData.ResponseMimeType)
+                && responseData.StatusCode.HasValue
+                && responseData.Stream != null)
+            {
+                responseData.ResponseMimeType = "application/json";
+            }
+
+            // This is much friendlier than the "Attempt to read a closed stream" message that will otherwise occur.
+            if ( responseData.Stream != null && !responseData.StatusCode.HasValue)
+            {
+                throw new ArgumentException("If a response stream is set, a status code must also be set.");
+            }
 
             //Basically all requests, even HEAD requests (e.g. AliasExists) need to have a stream to work correctly.
             //Note, a stream of nothing is still a stream.  So if you did not set a stream, we will do it for you.
             //I am sure this will cause issues when trying to test failures of other kinds...  Good use of 4hrs tracking
             //this stupid issue down.
-            if (builder.Stream == null) 
+            if (responseData.Stream == null)
             {
                 using (MemoryStream stream = new MemoryStream(new byte[0])) {
-                    builder.Stream = stream;
+                    responseData.Stream = stream;
                 }
             }
         }
 
-        ElasticsearchResponse<TReturn> IConnection.Request<TReturn>(RequestData requestData)            
+        TReturn IConnection.Request<TReturn>(RequestData requestData)
         {
-            ResponseBuilder<TReturn> builder = new ResponseBuilder<TReturn>(requestData);
+            Exception processingException = null;
+            ResponseData responseData = new ResponseData();
 
-            this.ProcessRequest<TReturn>(requestData, builder);
+            try
+            {
+                this.ProcessRequest<TReturn>(requestData, responseData);
+            }
+            catch (System.Exception ex)
+            {
+                processingException = ex;
+            }
 
-            return builder.ToResponse();
+            return ResponseBuilder.ToResponse<TReturn>(requestData, processingException, responseData.StatusCode, null, responseData.Stream, responseData.ResponseMimeType);
         }
 
-        async Task<ElasticsearchResponse<TReturn>> IConnection.RequestAsync<TReturn>(RequestData requestData, System.Threading.CancellationToken cancellationToken)
+        async Task<TReturn> IConnection.RequestAsync<TReturn>(RequestData requestData, System.Threading.CancellationToken cancellationToken)
         {
+            Exception processingException = null;
+            ResponseData responseData = new ResponseData();
 
-            ResponseBuilder<TReturn> builder = new ResponseBuilder<TReturn>(requestData, cancellationToken);
+            try
+            {
+                this.ProcessRequest<TReturn>(requestData, responseData);
+            }
+            catch (System.Exception ex)
+            {
+                processingException = ex;
+            }
 
-            this.ProcessRequest<TReturn>(requestData, builder);
-
-            return await builder.ToResponseAsync().ConfigureAwait(false);
+            return await ResponseBuilder.ToResponseAsync<TReturn>(requestData, processingException, responseData.StatusCode, null, responseData.Stream, responseData.ResponseMimeType, cancellationToken);
         }
 
         /// <summary>
-        /// Helper function to extract the postbody (as JObject) from a request.
+        /// Helper function to extract the body of a request that would be sent to the Elasticsearch server.
         /// </summary>
-        /// <param name="requestData"></param>
-        /// <returns></returns>
+        /// <param name="requestData">The request object</param>
+        /// <returns>JObject containing the request</returns>
         public JObject GetRequestPost(RequestData requestData)
         {
             //Some requests can have this as null.  That is ok...
@@ -159,12 +215,8 @@ namespace NCI.OCPL.Api.Common.Testing
 
             using (MemoryStream stream = new MemoryStream())
             {
-
-                //requestData.PostBody
                 requestData.PostData.Write(stream, requestData.ConnectionSettings);
-
                 postBody = Encoding.UTF8.GetString(stream.ToArray());
-
             }
 
             return JObject.Parse(postBody);

--- a/src/NCI.OCPL.Api.Common.Testing/NCI.OCPL.Api.Common.Testing.csproj
+++ b/src/NCI.OCPL.Api.Common.Testing/NCI.OCPL.Api.Common.Testing.csproj
@@ -8,8 +8,9 @@
     <Compile Remove="Class1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NEST" Version="5.6.1" />
+    <PackageReference Include="NEST" Version="7.9.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 </Project>

--- a/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
+++ b/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
-    <PackageReference Include="NEST" Version="5.6.1" />
+    <PackageReference Include="NEST" Version="7.9.0" />
     <PackageReference Include="NSwag.AspNetCore" Version="13.2.2" />
     <PackageReference AllowExplicitVersion="True" Include="Microsoft.AspNetCore.App" Version="2.1.4" />
   </ItemGroup>

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Services/ESListingInfoQueryServiceTest.GetByIds.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Services/ESListingInfoQueryServiceTest.GetByIds.cs
@@ -48,12 +48,12 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
                 res.StatusCode = 200;
 
                 esURI = req.Uri;
-                esContentType = req.ContentType;
+                esContentType = req.RequestMimeType;
                 esMethod = req.Method;
                 requestBody = conn.GetRequestPost(req);
             });
 
-            // The URI does not matter, an InMemoryConnection never requests from the server.
+            // The URI does not matter, an intercepting connector never requests from the server.
             var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 
             var connectionSettings = new ConnectionSettings(pool, conn);
@@ -68,7 +68,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
             // sets up the request correctly.
             await query.GetByIds(codes);
 
-            Assert.Equal("/listingpagev1/ListingInfo/_search", esURI.AbsolutePath);
+            Assert.Equal("/listingpagev1/_search", esURI.AbsolutePath);
             Assert.Equal("application/json", esContentType);
             Assert.Equal(HttpMethod.POST, esMethod);
             Assert.Equal(expectedRequest, requestBody, new JTokenEqualityComparer());
@@ -86,7 +86,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
                 throw new Exception();
             });
 
-            // While this has a URI, it does not matter, an InMemoryConnection never requests
+            // While this has a URI, it does not matter, an intercepting connector never requests
             // from the server.
             var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 
@@ -135,7 +135,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
 
             });
 
-            // While this has a URI, it does not matter, an InMemoryConnection never requests
+            // While this has a URI, it does not matter, an intercepting connection never requests
             // from the server.
             var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 
@@ -196,7 +196,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
                 res.StatusCode = 200;
             });
 
-            // The URI does not matter, an InMemoryConnection never requests from the server.
+            // The URI does not matter, an intercepting connector never requests from the server.
             var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 
             var connectionSettings = new ConnectionSettings(pool, conn);

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Services/ESListingInfoQueryServiceTest.GetByPrettyUrlName.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Services/ESListingInfoQueryServiceTest.GetByPrettyUrlName.cs
@@ -48,12 +48,12 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
                 res.StatusCode = 200;
 
                 esURI = req.Uri;
-                esContentType = req.ContentType;
+                esContentType = req.RequestMimeType;
                 esMethod = req.Method;
                 requestBody = conn.GetRequestPost(req);
             });
 
-            // The URI does not matter, an InMemoryConnection never requests from the server.
+            // The URI does not matter, an intercepting connector never requests from the server.
             var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 
             var connectionSettings = new ConnectionSettings(pool, conn);
@@ -68,7 +68,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
             // sets up the request correctly.
             await query.GetByPrettyUrlName(theName);
 
-            Assert.Equal("/listingpagev1/ListingInfo/_search", esURI.AbsolutePath);
+            Assert.Equal("/listingpagev1/_search", esURI.AbsolutePath);
             Assert.Equal("application/json", esContentType);
             Assert.Equal(HttpMethod.POST, esMethod);
             Assert.Equal(expectedRequest, requestBody, new JTokenEqualityComparer());
@@ -86,7 +86,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
                 throw new Exception();
             });
 
-            // While this has a URI, it does not matter, an InMemoryConnection never requests
+            // While this has a URI, it does not matter, an intercepting connector never requests
             // from the server.
             var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 
@@ -135,7 +135,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
 
             });
 
-            // While this has a URI, it does not matter, an InMemoryConnection never requests
+            // While this has a URI, it does not matter, an intercepting connector never requests
             // from the server.
             var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 
@@ -192,7 +192,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
                 res.StatusCode = 200;
             });
 
-            // The URI does not matter, an InMemoryConnection never requests from the server.
+            // The URI does not matter, an intercepting connector never requests from the server.
             var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 
             var connectionSettings = new ConnectionSettings(pool, conn);

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Services/ESTrialTypeQueryServiceTest.Get.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Services/ESTrialTypeQueryServiceTest.Get.cs
@@ -55,12 +55,12 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
                 res.StatusCode = 200;
 
                 esURI = req.Uri;
-                esContentType = req.ContentType;
+                esContentType = req.RequestMimeType;
                 esMethod = req.Method;
                 requestBody = conn.GetRequestPost(req);
             });
 
-            // The URI does not matter, an InMemoryConnection never requests from the server.
+            // The URI does not matter, an intercepting connector never requests from the server.
             var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 
             var connectionSettings = new ConnectionSettings(pool, conn);
@@ -75,7 +75,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
             // sets up the request correctly.
             await query.Get(theName);
 
-            Assert.Equal("/trialtypeinfov1/TrialTypeInfo/_search", esURI.AbsolutePath);
+            Assert.Equal("/trialtypeinfov1/_search", esURI.AbsolutePath);
             Assert.Equal("application/json", esContentType);
             Assert.Equal(HttpMethod.POST, esMethod);
             Assert.Equal(expectedRequest, requestBody, new JTokenEqualityComparer());
@@ -93,7 +93,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
 
             });
 
-            // While this has a URI, it does not matter, an InMemoryConnection never requests
+            // While this has a URI, it does not matter, an intercepting connector never requests
             // from the server.
             var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 
@@ -128,7 +128,6 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
                 ),
                 Times.Once
             );
-            // _mockLogger.Verify(x => x.Log(Microsoft.Extensions.Logging.LogLevel.Error, It.IsAny<Exception>(), "Invalid response when searching for pretty URL name or identifier 'chicken'."), Times.Once);
         }
 
         public static IEnumerable<object[]> Get_Success_Scenarios = new[]
@@ -151,7 +150,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
                 res.StatusCode = 200;
             });
 
-            // The URI does not matter, an InMemoryConnection never requests from the server.
+            // The URI does not matter, an intercepting connector never requests from the server.
             var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
 
             var connectionSettings = new ConnectionSettings(pool, conn);

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_BaseScenario.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByIds/GetByIds_BaseScenario.cs
@@ -1,5 +1,3 @@
-using Newtonsoft.Json.Linq;
-
 namespace NCI.OCPL.Api.CTSListingPages.Tests
 {
     public abstract class GetByIds_BaseScenario

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByPrettyUrlName/GetByPrettyUrlName_BaseScenario.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESListingInfoQueryService/GetByPrettyUrlName/GetByPrettyUrlName_BaseScenario.cs
@@ -1,5 +1,3 @@
-using Newtonsoft.Json.Linq;
-
 namespace NCI.OCPL.Api.CTSListingPages.Tests
 {
     public abstract class GetByPrettyUrlName_BaseScenario

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESTrialTypeQueryService/Get_MultipleResults.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/TestDataObjects/ESTrialTypeQueryService/Get_MultipleResults.cs
@@ -39,7 +39,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
                     ""id_string"": ""treatment"",
                     ""label"": ""Treatment""
                 }
-            },
+            }
         ]
     }
 }";


### PR DESCRIPTION
- Refactor ElasticsearchInterceptingConnection to use the ResponseBuilder
  static class to replace the removed instance-based version.
- Remove `Types` argument from ES Request objects in query service classes.
- Modify tests to retrieve the new RequestData.RequestMimeType property
  which replaces ContentType.
- Modify tests to remove document type from expected request paths.
- Update integration test data.
- Clean up unnecessary using statements.
- Update local integration tests to use Elasticsearch 7.9.2.
- Update GitHub integration test workflow to Elasticsearch 7.9.2.
- Fix bad JSON in unit test data that just randomly started being diagnosed.

Closes #38 
