### PR TITLE
Cross-site scripting fix

### DIFF
--- a/integration-tests/features/label-information/get/name-match.feature
+++ b/integration-tests/features/label-information/get/name-match.feature
@@ -4,6 +4,7 @@ Feature: Get trial type info by specifying the name.
         * url apiHost
 
     Scenario Outline: Validate the query results when matching against name.
+        for name: '<name>'
 
         Given path 'trial-type', name
         When method get

--- a/integration-tests/features/label-information/get/not-found-chicken.json
+++ b/integration-tests/features/label-information/get/not-found-chicken.json
@@ -1,3 +1,3 @@
 {
-    "Message": "Could not find label or identifier 'chicken'."
+    "Message": "Could not find the requested label or identifier."
 }

--- a/integration-tests/features/label-information/get/not-found-screening-diagnostic.json
+++ b/integration-tests/features/label-information/get/not-found-screening-diagnostic.json
@@ -1,3 +1,3 @@
 {
-    "Message": "Could not find label or identifier 'screening-diagnostic'."
+    "Message": "Could not find the requested label or identifier."
 }

--- a/integration-tests/features/label-information/get/not-found.feature
+++ b/integration-tests/features/label-information/get/not-found.feature
@@ -4,6 +4,7 @@ Feature: Fail to retrieve trial type info by specifying a nonexistent name.
         * url apiHost
 
     Scenario Outline: Validate no result found when matching against name.
+        for name '<name>'
 
         Given path 'trial-type', name
         When method get

--- a/integration-tests/features/listing-information/getByIds/errors-excess-code.json
+++ b/integration-tests/features/listing-information/getByIds/errors-excess-code.json
@@ -1,3 +1,3 @@
 {
-    "Message": "Could not find codes 'C115332,C7705,C3359,C9130,C0001'."
+    "Message": "Could not find the requested codes."
 }

--- a/integration-tests/features/listing-information/getByIds/errors-invalid-code.json
+++ b/integration-tests/features/listing-information/getByIds/errors-invalid-code.json
@@ -1,3 +1,3 @@
 {
-    "Message": "Could not find codes 'chicken'."
+    "Message": "Could not find the requested codes."
 }

--- a/integration-tests/features/listing-information/getByIds/errors-multiple-nonexistent-codes.json
+++ b/integration-tests/features/listing-information/getByIds/errors-multiple-nonexistent-codes.json
@@ -1,3 +1,3 @@
 {
-    "Message": "Could not find codes 'C0000,C0001'."
+    "Message": "Could not find the requested codes."
 }

--- a/integration-tests/features/listing-information/getByIds/errors-nonexistent-code.json
+++ b/integration-tests/features/listing-information/getByIds/errors-nonexistent-code.json
@@ -1,3 +1,3 @@
 {
-    "Message": "Could not find codes 'C0000'."
+    "Message": "Could not find the requested codes."
 }

--- a/integration-tests/features/listing-information/getByIds/errors-partially-overlapping-codes.json
+++ b/integration-tests/features/listing-information/getByIds/errors-partially-overlapping-codes.json
@@ -1,3 +1,3 @@
 {
-    "Message": "Could not find codes 'C115332,C7705,C0001'."
+    "Message": "Could not find the requested codes."
 }

--- a/integration-tests/features/listing-information/getByIds/id-found.feature
+++ b/integration-tests/features/listing-information/getByIds/id-found.feature
@@ -4,7 +4,7 @@ Feature: Get listing information records by specifying their c-code(s).
         * url apiHost
 
     Scenario Outline: Validate the query results when matching against c-code(s).
-
+        for code list: '<code>'
 
         Given path 'listing-information', 'get'
         And params { ccode: <code> }

--- a/integration-tests/features/listing-information/getByName/name-match.feature
+++ b/integration-tests/features/listing-information/getByName/name-match.feature
@@ -4,6 +4,7 @@ Feature: Get listing information records by specifying their pretty URL name.
         * url apiHost
 
     Scenario Outline: Validate the query results when matching against a pretty-url name.
+        for pretty name: '<prettyName>'
 
         Given path 'listing-information', prettyName
         When method get

--- a/integration-tests/features/listing-information/getByName/name-mismatch-not-a-match.json
+++ b/integration-tests/features/listing-information/getByName/name-mismatch-not-a-match.json
@@ -1,3 +1,3 @@
 {
-    "Message": "Could not find pretty URL name 'chicken'."
+    "Message": "Could not find the requested pretty URL name."
 }

--- a/integration-tests/features/listing-information/getByName/name-mismatch-partial-match.json
+++ b/integration-tests/features/listing-information/getByName/name-mismatch-partial-match.json
@@ -1,3 +1,3 @@
 {
-    "Message": "Could not find pretty URL name 'adult-soft'."
+    "Message": "Could not find the requested pretty URL name."
 }

--- a/integration-tests/features/listing-information/getByName/name-mismatch.feature
+++ b/integration-tests/features/listing-information/getByName/name-mismatch.feature
@@ -4,6 +4,7 @@ Feature: Fail to retrieve records when an invalid pretty URL name is specified.
         * url apiHost
 
     Scenario Outline: Validate the query results when matching against a pretty-url name.
+        for pretty name: '<prettyName>'
 
         Given path 'listing-information', prettyName
         When method get

--- a/src/NCI.OCPL.Api.CTSListingPages/Controllers/ListingInformationController.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Controllers/ListingInformationController.cs
@@ -62,7 +62,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Controllers
             }
 
             if (result == null)
-                throw new APIErrorException(404, $"Could not find pretty URL name '{prettyUrlName}'.");
+                throw new APIErrorException(404, "Could not find the requested pretty URL name.");
 
             return result;
         }
@@ -91,10 +91,13 @@ namespace NCI.OCPL.Api.CTSListingPages.Controllers
             }
 
             if (results == null || results.Length == 0)
-                throw new APIErrorException(404, $"Could not find codes '{string.Join(",", ccode)}'.");
+                throw new APIErrorException(404, "Could not find the requested codes.");
 
             if (results.Length > 1)
-                throw new APIErrorException(409, $"Multiple records found for codes '{string.Join(",", ccode)}'.");
+            {
+                _logger.LogWarning($"Multiple records found for code(s): '{String.Join(',', ccode)}'.");
+                throw new APIErrorException(409, "Multiple records found.");
+            }
 
             return results.First();
         }

--- a/src/NCI.OCPL.Api.CTSListingPages/Controllers/TrialTypeController.cs
+++ b/src/NCI.OCPL.Api.CTSListingPages/Controllers/TrialTypeController.cs
@@ -59,7 +59,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Controllers
             }
 
             if (result == null)
-                throw new APIErrorException(404, $"Could not find label or identifier '{name}'.");
+                throw new APIErrorException(404, "Could not find the requested label or identifier.");
 
             return result;
         }

--- a/src/NCI.OCPL.Api.CTSListingPages/appsettings.json
+++ b/src/NCI.OCPL.Api.CTSListingPages/appsettings.json
@@ -10,7 +10,7 @@
         "ListingInfoAliasName": "listinginfov1"
     },
     "NSwag": {
-        "Title": "CTS Listing Page API",
+        "Title": "Clinical Trial Listing Support API",
         "Description": "API for clinical trial listing pages"
     },
     "Logging": {

--- a/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Controllers/ListingInformationControllerTest.GetByIds.cs
+++ b/test/NCI.OCPL.Api.CTSListingPages.Tests/Tests/Controllers/ListingInformationControllerTest.GetByIds.cs
@@ -122,7 +122,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
                 () => controller.GetByIds(ccodes)
             );
 
-            Assert.Equal("Could not find codes 'C0000'.", exception.Message);
+            Assert.Equal("Could not find the requested codes.", exception.Message);
             Assert.Equal(404, exception.HttpStatusCode);
         }
 
@@ -170,7 +170,7 @@ namespace NCI.OCPL.Api.CTSListingPages.Tests
                 () => controller.GetByIds(ccodes)
             );
 
-            Assert.Equal("Multiple records found for codes 'C4872'.", exception.Message);
+            Assert.Equal("Multiple records found.", exception.Message);
             Assert.Equal(409, exception.HttpStatusCode);
         }
 


### PR DESCRIPTION
- #44 - Fix cross-site scripting vulnerability.
  - Remove user inputs from error messages.
  - Update expected values in unit and integration tests.
  - Add input values to scenario outline displays for all integration tests.
- #45 - Correct swagger page title.

Closes #44 
Closes #45 
