### PR TITLE
(#47) Sensitive headers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,5 @@ indent_style = space
 
 end_of_line = lf
 
-[*.yml]
+[*.yml;*.config]
 indent_size = 2

--- a/src/NCI.OCPL.Api.CTSListingPages/web.config
+++ b/src/NCI.OCPL.Api.CTSListingPages/web.config
@@ -11,6 +11,19 @@
           <fileExtensions allowUnlisted="true" />
         </requestFiltering>
       </security>
+      <httpProtocol>
+        <customHeaders>
+          <remove name="X-Powered-By" />
+        </customHeaders>
+      </httpProtocol>
+      <rewrite>
+        <outboundRules rewriteBeforeCache="true">
+          <rule name="Rewrite Server header">
+            <match serverVariable="RESPONSE_Server" pattern=".*" />
+            <action type="Rewrite" value="WebApis" />
+          </rule>
+        </outboundRules>
+      </rewrite>
     </system.webServer>
   </location>
 </configuration>

--- a/src/NCI.OCPL.Api.Common/Controllers/DefaultController.cs
+++ b/src/NCI.OCPL.Api.Common/Controllers/DefaultController.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Mvc;
+using NCI.OCPL.Api.Common;
+
+namespace NCI.OCPL.Api.Common.Controllers
+{
+  /// <summary>
+  /// Default controller, handles all unknown routes. This is a bit hacky, but without it,
+  /// Kestrel won't output a Server header, which in turn causes IIS to put in one of its
+  /// own with a version number, and leaking the server version number is considered a
+  /// security risk. Perhaps this can be removed one day.
+  /// </summary>
+  [Route("/")]
+  public class DefaultController : ControllerBase
+  {
+
+    /// <summary>
+    /// Handle unknown routes for all the verbs.
+    /// </summary>
+    [HttpDelete("{*wildcard}")]
+    [HttpGet("{*wildcard}")]
+    [HttpHead("{*wildcard}")]
+    [HttpOptions("{*wildcard}")]
+    [HttpPatch("{*wildcard}")]
+    [HttpPost("{*wildcard}")]
+    [HttpPut("{*wildcard}")]
+    public string Error()
+    {
+      throw new APIErrorException(404, "Invalid Route.");
+    }
+  }
+}


### PR DESCRIPTION
- Remove "X-Powered-By" header from IIS.
- Remove "Server" header from API
- Prevent IIS from adding a server header with a version.