### PR TITLE
Hide default controller from Swagger

### DIFF
--- a/src/NCI.OCPL.Api.Common/Controllers/DefaultController.cs
+++ b/src/NCI.OCPL.Api.Common/Controllers/DefaultController.cs
@@ -12,6 +12,7 @@ namespace NCI.OCPL.Api.Common.Controllers
   /// security risk. Perhaps this can be removed one day.
   /// </summary>
   [Route("/")]
+  [ApiExplorerSettings(IgnoreApi = true)]
   public class DefaultController : ControllerBase
   {
 


### PR DESCRIPTION
Fix a silly item with the "Default" route showing up when the Swagger document is generated.

Closes #50 