### PR TITLE
(#67) Bump NSwag.AspNetCore to v13.20

### DIFF
--- a/src/NCI.OCPL.Api.CTSListingPages/NCI.OCPL.Api.CTSListingPages.csproj
+++ b/src/NCI.OCPL.Api.CTSListingPages/NCI.OCPL.Api.CTSListingPages.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="NCI.OCPL.Api.Common" Version="2.1.*" />
-    <PackageReference Include="NSwag.AspNetCore" Version="13.11.*" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.20.*" />
     <PackageReference Include="NEST" Version="7.9.*" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #67

Testing needs:
- Standard regression tests
- Verify navigating to https://webapis-dev.cancer.gov/triallistingsupport/v1/index.html?configUrl=https://jumpy-floor.surge.sh/test.json displays the trial listing support Swagger page.